### PR TITLE
Don't call trim()

### DIFF
--- a/autoload/context.vim
+++ b/autoload/context.vim
@@ -419,7 +419,7 @@ function! s:join_pending(base, pending) abort
             let joined.text .= s:ellipsis . ' '
         endif
 
-        let joined.text .= trim(line.text)
+        let joined.text .= s:trim(line.text)
         let joined.number = line.number
     endfor
 
@@ -461,7 +461,7 @@ function! s:display_line(index, line) abort
     return a:line.text
 
     " NOTE: comment out the line above to include this debug info
-    let n = &columns - 25 - strchars(trim(a:line.text)) - a:line.indent
+    let n = &columns - 25 - strchars(s:trim(a:line.text)) - a:line.indent
     return printf("%s%s // %2d n:%5d i:%2d", a:line.text, repeat(' ', n), a:index+1, a:line.number, a:line.indent)
 endfunction
 
@@ -475,6 +475,10 @@ endfunction
 
 function! s:join_line(line) abort
     return a:line =~ g:context_join_regex
+endfunction
+
+function s:trim(string) abort
+    return substitute(a:string, '^\s*', '', '')
 endfunction
 
 " debug logging, set g:context_logfile to activate

--- a/plugin/context.vim
+++ b/plugin/context.vim
@@ -59,7 +59,7 @@ command! -bar ContextUpdate   call context#update(0, 0)
 " mappings
 if g:context_add_mappings
     " NOTE: in the zz/zt/zb mappings we invoke zz/zt/zb twice before calling
-    " update_context(). unfortunately this is needed because it seems like Vim
+    " context#update(). unfortunately this is needed because it seems like Vim
     " sometimes gets confused if the window height changes shortly after zz/zt/zb
     " have been executed.
     nnoremap <silent> <C-L> <C-L>:call context#update(1, 0)<CR>


### PR DESCRIPTION
>As it has been only added in Vim 8.0.1630
Use substitute() instead

Close #3