### PR TITLE
Disable cursorline in context buffer

### DIFF
--- a/autoload/context.vim
+++ b/autoload/context.vim
@@ -276,6 +276,7 @@ function! s:open_preview() abort
                 \ ' buftype=nofile' .
                 \ ' modifiable'     .
                 \ ' nobuflisted'    .
+                \ ' nocursorline'   .
                 \ ' nonumber'       .
                 \ ' noswapfile'     .
                 \ ' nowrap'         .


### PR DESCRIPTION
This prevents the first line from being highlighted in the context buffer for people who have `cursorline` enabled by default.