### PR TITLE
Fix padding by disabling relativenumber and signcolumn

### DIFF
--- a/autoload/context.vim
+++ b/autoload/context.vim
@@ -272,14 +272,16 @@ endfunction
 " https://vi.stackexchange.com/questions/19056/how-to-create-preview-window-to-display-a-string
 function! s:open_preview() abort
     call s:echof('> open_preview')
-    let settings = '+setlocal'      .
-                \ ' buftype=nofile' .
-                \ ' modifiable'     .
-                \ ' nobuflisted'    .
-                \ ' nocursorline'   .
-                \ ' nonumber'       .
-                \ ' noswapfile'     .
-                \ ' nowrap'         .
+    let settings = '+setlocal'        .
+                \ ' buftype=nofile'   .
+                \ ' modifiable'       .
+                \ ' nobuflisted'      .
+                \ ' nocursorline'     .
+                \ ' nonumber'         .
+                \ ' norelativenumber' .
+                \ ' noswapfile'       .
+                \ ' nowrap'           .
+                \ ' signcolumn=no'    .
                 \ ''
     execute 'silent! aboveleft pedit' escape(settings, ' ') s:buffer_name
 endfunction


### PR DESCRIPTION
Both `signcolumn` and `relativenumber` are set per default in my vimrc.
Also in the preview window that the plugin opens.

So in my case I effectively had twice the padding.
![context](https://user-images.githubusercontent.com/7143573/70924112-487b2780-2029-11ea-9a6d-e711c2241865.png)

Disabling both fixes the problem.