### PR TITLE
8 Preview window follow split windows

### DIFF
--- a/autoload/context.vim
+++ b/autoload/context.vim
@@ -549,8 +549,9 @@ function! s:limit(lines, diff_want, indent) abort
     endif
 
     let diff = len(a:lines) - max
-    if diff > a:diff_want
-        let max += diff
+    let diff2 = diff - a:diff_want
+    if diff2 > 0
+        let max += diff2
     endif
 
     let limited = a:lines[: max/2-1]

--- a/autoload/context.vim
+++ b/autoload/context.vim
@@ -378,6 +378,8 @@ function! s:show_in_preview(lines) abort
     let tabstop  = &tabstop
     let padding  = wincol() - virtcol('.')
 
+    call s:close_without_equalize()
+
     " based on https://stackoverflow.com/questions/13707052/quickfix-preview-window-resizing
     silent! wincmd P " jump to preview, but don't show error
     if &previewwindow
@@ -434,6 +436,20 @@ function! s:show_in_preview(lines) abort
     execute 'resize' s:min_height
 
     wincmd p " jump back
+endfunction
+
+" https://www.reddit.com/r/vim/comments/e7l4m1/welllecontextvim_vim_plugin_that_shows_the/fa4tz1g/
+function! s:close_without_equalize() abort
+    let pwin = index(map(range(1, winnr('$')), "getwinvar(v:val, '&pvw')"), 1) + 1
+    if pwin == 0
+        return
+    endif
+
+    let wfh_save = map(range(1,winnr('$')), "getwinvar(v:val, '&wfh')")
+    call map(range(1, winnr('$')), "setwinvar(v:val, '&wfh', 1)")
+    pclose
+    call remove(wfh_save, pwin-1)
+    call map(range(1, winnr('$')), "setwinvar(v:val, '&wfh', wfh_save[v:val-1])")
 endfunction
 
 " NOTE: this function updates the statusline too, as it depends on the padding

--- a/autoload/context.vim
+++ b/autoload/context.vim
@@ -440,16 +440,19 @@ endfunction
 
 " https://www.reddit.com/r/vim/comments/e7l4m1/welllecontextvim_vim_plugin_that_shows_the/fa4tz1g/
 function! s:close_without_equalize() abort
+    " TODO: probably not needed like this anymore?
     let pwin = index(map(range(1, winnr('$')), "getwinvar(v:val, '&pvw')"), 1) + 1
     if pwin == 0
         return
     endif
 
-    let wfh_save = map(range(1,winnr('$')), "getwinvar(v:val, '&wfh')")
-    call map(range(1, winnr('$')), "setwinvar(v:val, '&wfh', 1)")
-    pclose
-    call remove(wfh_save, pwin-1)
-    call map(range(1, winnr('$')), "setwinvar(v:val, '&wfh', wfh_save[v:val-1])")
+    if &equalalways
+        set noequalalways
+        pclose
+        let layout = winrestcmd() | set equalalways | noautocmd execute layout
+    else
+        pclose
+    endif
 endfunction
 
 " NOTE: this function updates the statusline too, as it depends on the padding


### PR DESCRIPTION
Close #8 

When using multiple splits the preview window didn't follow the active window. This was because using `pclose` did rearrange windows. On https://www.reddit.com/r/vim/comments/e7l4m1 I got some help from `/u/bradagy` on how this can be fixed. This PR changes the behavior so the preview window follows the active window.

It also changes how state of the preview window is stored as it should now be per window, not global.