### PR TITLE
Added ability to blacklist specific filetypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ let g:context_join_regex = '^\W*$'
 ```
 If we extended the context on some indent, we will join a line of this indent into the one above if the lower one matches this regular expression. So back in the C-style case where our context contains an `if (condition)` line and a `{` line below, they will be merged to `if (condition) {`. And that is because the `{` line matched this regular expression. By default we join everything which has no word characters.
 
+```vim
+let g:context_filetype_blacklist = []
+```
+By default, no filetypes will be ignored for the context buffer to appear. If you wish to blacklist a specific filetype, add the name of the filetype to this list.
+
 
 ## Commands
 

--- a/autoload/context.vim
+++ b/autoload/context.vim
@@ -52,7 +52,9 @@ endfunction
 
 
 function! context#update(force_resize, autocmd) abort
-    if !g:context_enabled || !s:activated
+    if !g:context_enabled ||
+    \  !s:activated ||
+    \  index(g:context_filetype_blacklist, &filetype) != -1
         " call s:echof('  disabled')
         return
     endif

--- a/plugin/context.vim
+++ b/plugin/context.vim
@@ -47,6 +47,10 @@ let g:context_extend_regex = get(g:, 'context_extend_regex', '^\s*\([]{})]\|end\
 " for example a `{` might be lifted to the preceeding `if` line
 let g:context_join_regex = get(g:, 'context_join_regex', '^\W*$')
 
+" If you wish to blacklist a specific filetype, add the name of the filetype to
+" this list.
+let g:context_filetype_blacklist = get(g:, 'context_filetype_blacklist', [])
+
 
 " commands
 command! -bar ContextActivate call context#activate()


### PR DESCRIPTION
The new variable `g:context_filetype_blacklist` is intended to be used
as a list of strings where each string is a filetype we do not want the
context buffer to appear in. Add filetypes to the list to ignore them.