### PR TITLE
24 Fix FoldColumn highlighting

### DIFF
--- a/autoload/context/popup.vim
+++ b/autoload/context/popup.vim
@@ -209,8 +209,8 @@ function! s:open() abort
 
     let border = ' *' .g:context.char_border . '* ' . s:context_buffer_name . ' '
     let tag = s:context_buffer_name
-    let m = matchadd(g:context.highlight_border, border, 10, -1, {'window': popup})
-    let m = matchadd(g:context.highlight_tag,    tag,    10, -1, {'window': popup})
+    call matchadd(g:context.highlight_border, border, 10, -1, {'window': popup})
+    call matchadd(g:context.highlight_tag,    tag,    10, -1, {'window': popup})
 
     let buf = winbufnr(popup)
     call setbufvar(buf, '&syntax', &syntax)

--- a/autoload/context/popup/nvim.vim
+++ b/autoload/context/popup/nvim.vim
@@ -12,8 +12,10 @@ function! context#popup#nvim#open() abort
                 \ 'style':     'minimal',
                 \ })
 
-	call setwinvar(popup, '&winhighlight', 'Normal:' . g:context.highlight_normal)
     call setwinvar(popup, '&wrap', 0)
+    call setwinvar(popup, '&foldenable', 0)
+    call setwinvar(popup, '&winhighlight',
+                \ 'FoldColumn:Normal,Normal:' . g:context.highlight_normal)
 
     return popup
 endfunction

--- a/autoload/context/popup/vim.vim
+++ b/autoload/context/popup/vim.vim
@@ -7,8 +7,9 @@ function! context#popup#vim#open() abort
                 \ 'wrap':     v:false,
                 \ })
 
-	call setwinvar(popup, '&wincolor', g:context.highlight_normal)
+    call setwinvar(popup, '&wincolor', g:context.highlight_normal)
     call setwinvar(popup, '&tabstop', &tabstop)
+    call win_execute(popup, 'highlight! link FoldColumn Normal')
 
     return popup
 endfunction
@@ -26,7 +27,7 @@ function! context#popup#vim#redraw(winid, popup, lines) abort
                 \ 'maxwidth': c.size_w,
                 \ })
 
-	call win_execute(a:popup, 'set foldcolumn=' . c.padding)
+    call win_execute(a:popup, 'set foldcolumn=' . c.padding)
 endfunction
 
 function! context#popup#vim#close(popup) abort


### PR DESCRIPTION
>Make sure folding is disabled in popup windows.
Use Normal as highlighting for FoldColumn.
So if `g:context_highlight_normal` is used it should affect the sign column too.

Close #24