### PR TITLE
Ensure ContextToggle activates the plugin when lazy loading is used

### DIFF
--- a/autoload/context.vim
+++ b/autoload/context.vim
@@ -12,6 +12,7 @@ endfunction
 
 function! context#enable() abort
     let g:context.enabled = 1
+    unlet! w:context " clear stale cache
     call context#update('enable')
     echom 'context.vim: enabled'
 endfunction

--- a/plugin/context.vim
+++ b/plugin/context.vim
@@ -54,6 +54,6 @@ endif
 
 " lazy loading was used
 if v:vim_did_enter
-    let g:context_enabled = 0 " plugin was effectively disabled before load
+    let g:context.enabled = 0 " plugin was effectively disabled before load
     ContextActivate
 endif


### PR DESCRIPTION
This fixes a problem in which the initial call to `ContextToggle` disables the plugin instead of enabling it when it's loaded lazily.

## How to replicate
1. Lazily load the plugin with `Plug 'wellle/context.vim', {'on': 'ContextToggle'}`
2. Run `:ContextToggle`