### PR TITLE
Provide visible feedback when context.vim is enabled/disabled

### DIFF
--- a/autoload/context.vim
+++ b/autoload/context.vim
@@ -13,6 +13,7 @@ endfunction
 function! context#enable() abort
     let g:context.enabled = 1
     call context#update('enable')
+    echom 'context.vim: enabled'
 endfunction
 
 function! context#disable() abort
@@ -23,6 +24,8 @@ function! context#disable() abort
     else
         call context#popup#clear()
     endif
+
+    echom 'context.vim: disabled'
 endfunction
 
 function! context#toggle() abort


### PR DESCRIPTION
This helps with things like `:ContextToggle` because it's not always apparent at first glance whether context.vim is enabled or not.