### PR TITLE
Only show current status on :ContextToggle

### DIFF
--- a/autoload/context.vim
+++ b/autoload/context.vim
@@ -13,7 +13,6 @@ endfunction
 function! context#enable() abort
     let g:context.enabled = 1
     call context#update('enable')
-    echom 'context.vim: enabled'
 endfunction
 
 function! context#disable() abort
@@ -24,15 +23,15 @@ function! context#disable() abort
     else
         call context#popup#clear()
     endif
-
-    echom 'context.vim: disabled'
 endfunction
 
 function! context#toggle() abort
     if g:context.enabled
         call context#disable()
+        echom 'context.vim: disabled'
     else
         call context#enable()
+        echom 'context.vim: enabled'
     endif
 endfunction
 


### PR DESCRIPTION
This is another take at #35, plus some attempt to suppress the `Press ENTER` prompts. I'm not 100% sure if it would help with the latter since I can't reproduce the problem, so it would be great if you could try it out. Thanks.