### PR TITLE
Export indent to g:Context_indent_function

### DIFF
--- a/autoload/context/context.vim
+++ b/autoload/context/context.vim
@@ -65,7 +65,7 @@ function! s:get_context_line(line) abort
     let skipped = get(b:context.skips, a:line.number, -1)
     if skipped != -1
         " call context#util#echof('  skipped', a:line.number, '->', skipped)
-        return context#line#make(skipped, indent(skipped), getline(skipped))
+        return context#line#make(skipped, g:context.Indent_function(skipped), getline(skipped))
     endif
 
     " if line starts with closing brace or similar: jump to matching
@@ -89,7 +89,7 @@ function! s:get_context_line(line) abort
             return s:nil_line
         endif
 
-        let indent = indent(current_line)
+        let indent = g:context.Indent_function(current_line)
         if indent > max_indent
             " use skip if we have, next line otherwise
             let skipped = get(b:context.skips, current_line, current_line-1)

--- a/autoload/context/context.vim
+++ b/autoload/context/context.vim
@@ -65,7 +65,7 @@ function! s:get_context_line(line) abort
     let skipped = get(b:context.skips, a:line.number, -1)
     if skipped != -1
         " call context#util#echof('  skipped', a:line.number, '->', skipped)
-        return context#line#make(skipped, g:context.Indent_function(skipped), getline(skipped))
+        return context#line#make(skipped, g:context.Indent_function(skipped).indent, getline(skipped))
     endif
 
     " if line starts with closing brace or similar: jump to matching
@@ -89,7 +89,7 @@ function! s:get_context_line(line) abort
             return s:nil_line
         endif
 
-        let indent = g:context.Indent_function(current_line)
+        let indent = g:context.Indent_function(current_line).indent
         if indent > max_indent
             " use skip if we have, next line otherwise
             let skipped = get(b:context.skips, current_line, current_line-1)

--- a/autoload/context/line.vim
+++ b/autoload/context/line.vim
@@ -12,7 +12,7 @@ let s:nil_line = context#line#make(0, 0, '')
 function! context#line#get_base_line(line) abort
     let current_line = a:line
     while 1
-        let indent = indent(current_line)
+        let indent = g:context.Indent_function(current_line)
         if indent < 0 " invalid line
             return s:nil_line
         endif

--- a/autoload/context/line.vim
+++ b/autoload/context/line.vim
@@ -12,7 +12,7 @@ let s:nil_line = context#line#make(0, 0, '')
 function! context#line#get_base_line(line) abort
     let current_line = a:line
     while 1
-        let indent = g:context.Indent_function(current_line)
+        let indent = g:context.Indent_function(current_line).indent
         if indent < 0 " invalid line
             return s:nil_line
         endif

--- a/autoload/context/mapping.vim
+++ b/autoload/context/mapping.vim
@@ -36,7 +36,7 @@ function! context#mapping#ce() abort
     endif
 
     let next_top_line = w:context.top_line + v:count1
-    let [lines, _, _] = context#popup#get_context(next_top_line)
+    let [lines, _, _, _] = context#popup#get_context(next_top_line)
     if len(lines) == 0
         return suffix
     endif

--- a/autoload/context/popup.vim
+++ b/autoload/context/popup.vim
@@ -24,7 +24,7 @@ function! context#popup#get_context(base_line) abort
     while 1
         let line_offset += 1
         let line_number = a:base_line + line_offset
-        let indent = indent(line_number) "    -1 for invalid lines
+        let indent = g:context.Indent_function(line_number) "    -1 for invalid lines
         let line = getline(line_number)  " empty for invalid lines
         let base_line = context#line#make(line_number, indent, line)
 

--- a/autoload/context/preview.vim
+++ b/autoload/context/preview.vim
@@ -135,7 +135,7 @@ function! s:get_hidden_indent(base_line, lines) abort
             continue
         endif
 
-        return g:context.Indent_function(current_line)
+        return g:context.Indent_function(current_line).indent
     endwhile
 
     return -1

--- a/autoload/context/preview.vim
+++ b/autoload/context/preview.vim
@@ -135,7 +135,7 @@ function! s:get_hidden_indent(base_line, lines) abort
             continue
         endif
 
-        return indent(current_line)
+        return g:context.Indent_function(current_line)
     endwhile
 
     return -1

--- a/autoload/context/settings.vim
+++ b/autoload/context/settings.vim
@@ -39,6 +39,9 @@ function! context#settings#parse() abort
 
     let char_border = get(g:, 'context_border_char', '▬')
 
+    " Indent function
+    let Indent_function = get(g:, 'Context_indent_function',  {line -> indent(line)})
+
     " lines matching this regex will be ignored for the context
     " match whitespace only lines to show the full context
     " also by default excludes comment lines etc.
@@ -87,5 +90,6 @@ function! context#settings#parse() abort
                 \ 'logfile':             logfile,
                 \ 'ellipsis':            repeat(char_ellipsis, 3),
                 \ 'ellipsis5':           repeat(char_ellipsis, 5),
+                \ 'Indent_function':     Indent_function,
                 \ }
 endfunction

--- a/autoload/context/settings.vim
+++ b/autoload/context/settings.vim
@@ -40,7 +40,7 @@ function! context#settings#parse() abort
     let char_border = get(g:, 'context_border_char', '▬')
 
     " Indent function
-    let Indent_function = get(g:, 'Context_indent_function',  {line -> indent(line)})
+    let Indent_function = get(g:, 'Context_indent_function',  function('s:default_indent'))
 
     " lines matching this regex will be ignored for the context
     " match whitespace only lines to show the full context
@@ -92,4 +92,9 @@ function! context#settings#parse() abort
                 \ 'ellipsis5':           repeat(char_ellipsis, 5),
                 \ 'Indent_function':     Indent_function,
                 \ }
+endfunction
+
+function s:default_indent(line)
+  let indent = indent(a:line)
+  return {'indent':indent, 'border_line': repeat(' ', indent)}
 endfunction


### PR DESCRIPTION
g:Context_indent_function being a funcref has to start with an uppercase
(unless there is a way to get away with it)

I'm not expecting you to accept the pull request, it's just a proof of concept, it works in theory
but defining custom function seems a bit more tricky than expected.

Example for markdown and orgmode (and indentation)

```vim
function MyIndent(line)
  let line = getline(a:line)
  let headings = match(line, '^*\+\zs\s')+1
  if headings <= 0
    let headings = match(line, '^#\+\zs\s')+1
    if headings <= 0
      let headings = 5
    endif
  endif
  return indent(a:line)+headings
endfunction

let g:Context_indent_function = funcref("MyIndent")
let g:context_skip_regex = '^\s*$'
```

For some reason it hangs at the begining. I think `context` doesn't like to to start with a indent level of 5 on an empty file ....

#44