### PR TITLE
41 Allow shorter joined lines (disable ellipsis)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ If we extend the context on some indent we try to join them. By default we join 
 
 In complex cases there can be a big number of such context lines which we will join together. By default we only show up to 5 such parts.
 
-Note: This can happen if you have long lists of struct literals, so in the context it would look like `{ ··· }, { ··· }, { ··· }`
+Note: This can happen if you have long lists of struct literals, so in the context it would look like `{ ··· }, { ··· }, { ··· }`. Set `g:context_max_join_parts` to 2 or 1 to shorten this to `{ ···` or just `{` respectively.
 
 ```vim
 let g:context_ellipsis_char = '·'

--- a/autoload/context/context.vim
+++ b/autoload/context/context.vim
@@ -108,8 +108,7 @@ function! s:get_context_line(line) abort
 endfunction
 
 function! s:join(lines) abort
-    " only works with at least 3 parts, so disable otherwise
-    if g:context.max_join_parts < 3
+    if g:context.max_join_parts < 1
         return a:lines
     endif
 
@@ -141,13 +140,20 @@ function! s:join_pending(base, pending) abort
         return a:base
     endif
 
+    let joined = a:base
+    if g:context.max_join_parts < 3
+        if g:context.max_join_parts == 2
+            let joined.text .= ' ' . g:context.ellipsis
+        endif
+        return joined
+    endif
+
     let max = g:context.max_join_parts
     if len(a:pending) > max-1
         call remove(a:pending, (max-1)/2-1, -max/2-1)
         call insert(a:pending, s:nil_line, (max-1)/2-1) " middle marker
     endif
 
-    let joined = a:base
     for line in a:pending
         let joined.text .= ' '
         if line.number == 0


### PR DESCRIPTION
>Handle g:context_max_join_parts < 3
>
>Set it to 2 to show it as `{ ···`
>Set it to 1 to show it as `{`

Close #41