### PR TITLE
44 Fix border line indentation

### DIFF
--- a/autoload/context.vim
+++ b/autoload/context.vim
@@ -78,7 +78,7 @@ function! context#update(...) abort
                     \ 'pos_x':         0,
                     \ 'size_h':        0,
                     \ 'size_w':        0,
-                    \ 'base_line':     0,
+                    \ 'indent':        0,
                     \ 'needs_layout':  0,
                     \ 'needs_move':    0,
                     \ 'needs_update':  0,

--- a/autoload/context/popup.vim
+++ b/autoload/context/popup.vim
@@ -5,7 +5,7 @@ function! context#popup#update_context() abort
     call context#util#echof('> context#popup#update_context', len(lines_top))
     let w:context.lines_top    = lines_top
     let w:context.lines_bottom = lines_bottom
-    let w:context.base_line    = base_line
+    let w:context.indent       = g:context.Border_indent(base_line)
     call s:show()
 endfunction
 
@@ -228,18 +228,13 @@ endfunction
 
 function! s:get_border_line(winid, indent) abort
     let c = getwinvar(a:winid, 'context')
+    let indent = a:indent ? c.indent : 0
 
-    let prefix = ''
-    if a:indent
-        let indent = g:context.Border_indent(c.base_line)
-        let prefix = repeat(' ', indent)
-    endif
-
-    let line_len = c.size_w - len(prefix) - len(s:context_buffer_name) - 2 - c.padding
+    let line_len = c.size_w - indent - len(s:context_buffer_name) - 2 - c.padding
     " NOTE: we use a non breaking space before the buffer name because there
     " can be some display issues in the Kitty terminal with a normal space
     return ''
-                \ . prefix
+                \ . repeat(' ', indent)
                 \ . repeat(g:context.char_border, line_len)
                 \ . ' '
                 \ . s:context_buffer_name


### PR DESCRIPTION
>There was an issue when switching between splits where the border line indent was recalculated based on the base line number, but getting the indent from the wrong buffer.
>
>This commit artially reverts e84ff920a344171d41c24ca7cbd9744b15022678 so we still cache the border line indent instead of the base line number, but still use the customizable border line indent function.

#44 #54 