### PR TITLE
Considers scrolloff when zt-ing

### DIFF
--- a/autoload/context/mapping.vim
+++ b/autoload/context/mapping.vim
@@ -71,7 +71,11 @@ function! context#mapping#zt() abort
         return 'zt' . suffix
     endif
 
-    let n = cursor_line - w:context.top_line - len(lines) - 1 - &scrolloff
+    if &scrolloff > len(lines)
+        let n = cursor_line - w:context.top_line - &scrolloff
+    else
+        let n = cursor_line - w:context.top_line - len(lines) - 1
+    endif
     " call context#util#echof('zt', w:context.top_line, cursor_line, len(lines), n)
 
     if n == 0

--- a/autoload/context/mapping.vim
+++ b/autoload/context/mapping.vim
@@ -71,7 +71,7 @@ function! context#mapping#zt() abort
         return 'zt' . suffix
     endif
 
-    let n = cursor_line - w:context.top_line - len(lines) - 1
+    let n = cursor_line - w:context.top_line - len(lines) - 1 - &scrolloff
     " call context#util#echof('zt', w:context.top_line, cursor_line, len(lines), n)
 
     if n == 0


### PR DESCRIPTION
Fixes #59

The issue I mentioned in #59 was independent of the other plugin I mentioned there and can be reproduced with just context.vim installed.

The problem is that if scrolloff is non-zero, the overridden `zt` will not move the cursor line to the top of the window plus the scrolloff, but it will cause the cursor to move down as many lines as the difference between the scrolloff and the context window height.

In the PR, I check if the scrolloff is more that then context window height.

If not, then the bottom of the context window becomes the new top of the buffer window (this is the behavior without my patch). If we look at the buffer window only, the effective scrolloff is zero.


If the scrolloff is more than the context window height, then there are two
options. One is to continue considering the bottom of the context window to be
the top  of the buffer window (see the first commit in my PR):

```
let n = cursor_line - w:context.top_line - &scrolloff
```

But this will cause inconsistencies. If the user presses `zt` and then `k`, nvim
will not know about the tricks context.vim uses and will still consider the top
of the buffer window to be the actual top and not the bottom of the context
window.


The second option is to follow what vim does and what I do in my second commit. The top of the buffer that is used is the real top, behind the floating window. The problem with this approach is that the effective scrolloff for the user is less than what they expect by as many lines as the height of the context window. But I think it is a good compromise. 