### PR TITLE
62 Add setting to hide the border line or the tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ If your Vim/Neovim version supports popup/floating windows we use these highligh
 
 If you use Vim you can define your own highlight group like `highlight MyColor ctermbg=lightblue` and set `g:context_highlight_normal` to `'MyColor'`. In Neovim this is currently not supported (see `:h 'winhl'`).
 
+Note: These highlight settings can also be used to hide the tag (`let g:context_highlight_tag = '<hide>'`) or the full border line (`let g:context_highlight_border = '<hide>'`).
+
 ```vim
 let g:context_skip_regex = '^\s*\($\|#\|//\|/\*\|\*\($\|/s\|\/\)\)'
 ```

--- a/autoload/context/popup.vim
+++ b/autoload/context/popup.vim
@@ -266,13 +266,21 @@ function! s:get_border_line(winid, indent) abort
     let c = getwinvar(a:winid, 'context')
     let indent = a:indent ? c.indent : 0
 
-    let line_len = c.size_w - indent - len(s:context_buffer_name) - 2 - c.padding
+    let line_len = c.size_w - c.padding - indent - 1
+    if g:context.show_tag
+        let line_len -= len(s:context_buffer_name) + 1
+    endif
+
     " NOTE: we use a non breaking space before the buffer name because there
     " can be some display issues in the Kitty terminal with a normal space
-    return ''
+    let border_line = ''
                 \ . repeat(' ', indent)
                 \ . repeat(g:context.char_border, line_len)
                 \ . ' '
-                \ . s:context_buffer_name
-                \ . ' '
+    if g:context.show_tag
+        let border_line .= ''
+                    \ . s:context_buffer_name
+                    \ . ' '
+    endif
+    return border_line
 endfunction

--- a/autoload/context/popup.vim
+++ b/autoload/context/popup.vim
@@ -21,6 +21,7 @@ function! context#popup#get_context(base_line) abort
     let skipped       =  0
     let context_count =  0 " how many contexts did we check?
     let line_offset   = -1 " first iteration starts with zero
+    let border_height = g:context.show_border
 
     while 1
         let line_offset += 1
@@ -49,8 +50,8 @@ function! context#popup#get_context(base_line) abort
         endif
         let context_count += 1
 
-        " this context fits, use it
-        if line_count < line_offset
+        if line_count + border_height <= line_offset
+            " this context fits, use it
             break
         endif
 
@@ -101,12 +102,16 @@ function! context#popup#get_context(base_line) abort
     " NOTE: this overwrites lines, from here on out it's just a list of string
     call map(lines, function('context#line#display'))
 
-    " success, we found a fitting context
-    while len(lines) < line_offset - skipped - 1
+    if g:context.show_border
+        call add(lines, '') " add line for border, will be replaced later
+    endif
+
+    " fill context until it reaches the skipped lines
+    " (to hide lines whose context didn't fit)
+    while len(lines) + skipped < line_offset
         call add(lines, '')
     endwhile
 
-    call add(lines, '') " will be replaced with border line
     return [lines, line_number]
 endfunction
 
@@ -161,7 +166,7 @@ function! context#popup#redraw(winid, force) abort
     endif
 
     let lines = c.lines
-    if len(lines) > 0
+    if g:context.show_border && len(lines) > 0
         let lines[-1] = s:get_border_line(a:winid, 1)
         let c.lines = lines
     endif

--- a/autoload/context/popup.vim
+++ b/autoload/context/popup.vim
@@ -247,7 +247,7 @@ function! s:open() abort
     endif
 
     " NOTE: we use a non breaking space here again before the buffer name
-    let border = ' *' .g:context.char_border . '* ' . s:context_buffer_name . ' '
+    let border = ' *' .g:context.char_border . '* '
     let tag = s:context_buffer_name
     call matchadd(g:context.highlight_border, border, 10, -1, {'window': popup})
     call matchadd(g:context.highlight_tag,    tag,    10, -1, {'window': popup})

--- a/autoload/context/settings.vim
+++ b/autoload/context/settings.vim
@@ -59,9 +59,23 @@ function! context#settings#parse() abort
     " for example a `{` might be lifted to the preceeding `if` line
     let regex_join = get(g:, 'context_join_regex', '^\W*$')
 
+    let default_highlight_border = 'Comment'
+    let default_highlight_tag    = 'Special'
+
     let highlight_normal = get(g:, 'context_highlight_normal', 'Normal')
-    let highlight_border = get(g:, 'context_highlight_border', 'Comment')
-    let highlight_tag    = get(g:, 'context_highlight_tag',    'Special')
+    let highlight_border = get(g:, 'context_highlight_border', default_highlight_border)
+    let highlight_tag    = get(g:, 'context_highlight_tag',    default_highlight_tag)
+    let show_border = 1
+    let show_tag    = 1
+
+    if highlight_border == '<hide>'
+        let highlight_border = default_highlight_border
+        let show_border = 0
+    endif
+    if highlight_tag == '<hide>'
+        let highlight_tag = default_highlight_tag
+        let show_tag = 0
+    endif
 
     " hopefully temporary: disable nvim redraw to avoid flicker, see popup/nvim.vim
     let nvim_no_redraw = get(g:, 'context_nvim_no_redraw', 0)
@@ -91,6 +105,8 @@ function! context#settings#parse() abort
                 \ 'highlight_normal':    highlight_normal,
                 \ 'highlight_border':    highlight_border,
                 \ 'highlight_tag':       highlight_tag,
+                \ 'show_border':         show_border,
+                \ 'show_tag':            show_tag,
                 \ 'nvim_no_redraw':      nvim_no_redraw,
                 \ 'logfile':             logfile,
                 \ 'ellipsis':            repeat(char_ellipsis, 3),


### PR DESCRIPTION
This PR adds special handling for those two settings:

```vim
let g:context_highlight_tag    = '<hide>'
let g:context_highlight_border = '<hide>'
```

The first one hides only the tag in the border line, the second hides the border line completely.

Close #62.