### PR TITLE
40 Show line numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ autocmd CursorMoved  * call context#update('CursorMoved')
 autocmd VimResized   * call context#update('VimResized')
 autocmd CursorHold   * call context#update('CursorHold')
 autocmd User GitGutter call context#update('GitGutter')
-autocmd OptionSet number,relativenumber,numberwidth,signcolumn,tabstop
+autocmd OptionSet number,relativenumber,numberwidth,signcolumn,tabstop,list
             \          call context#update('OptionSet')
 ```
 

--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ autocmd CursorMoved  * call context#update('CursorMoved')
 autocmd VimResized   * call context#update('VimResized')
 autocmd CursorHold   * call context#update('CursorHold')
 autocmd User GitGutter call context#update('GitGutter')
+autocmd OptionSet number,relativenumber,numberwidth,signcolumn,tabstop
+            \          call context#update('OptionSet')
 ```
 
 Note the `VimEnter` one. When Vim starts this plugin isn't active yet, even if enabled. That is because there are some issues with trying to open a preview window before Vim finished opening all windows for the provided file arguments. So if you disable auto commands you will need to call `:ContextActivate` in some way to activate this plugin.

--- a/autoload/context.vim
+++ b/autoload/context.vim
@@ -70,6 +70,8 @@ function! context#update(...) abort
                     \ 'indent':             0,
                     \ 'needs_layout':       0,
                     \ 'needs_update':       0,
+                    \ 'number_width':       0,
+                    \ 'sign_width':         0,
                     \ 'padding':            0,
                     \ 'top_line':           0,
                     \ 'bottom_line':        0,

--- a/autoload/context.vim
+++ b/autoload/context.vim
@@ -146,14 +146,14 @@ endfunction
 
 function! s:set_enabled(arg, enabled) abort
     if a:arg == 'window'
-        let winids = [winnr()] " only current window
+        let winnrs = [winnr()] " only current window
     else
-        let winids = range(1, winnr('$')) " all windows
+        let winnrs = range(1, winnr('$')) " all windows
         let g:context.enabled = a:enabled
     endif
 
-    for winid in winids
-        let c = getwinvar(win_getid(winid), 'context', {})
+    for winnr in winnrs
+        let c = getwinvar(win_getid(winnr), 'context', {})
         let c.enabled = a:enabled
         let c.top_line = 0 " don't rely on old cache
     endfor

--- a/autoload/context.vim
+++ b/autoload/context.vim
@@ -97,6 +97,12 @@ function! context#update(...) abort
     call context#util#update_state()
     call context#util#update_window_state(winid)
 
+    if source == 'OptionSet'
+        " some options like 'relativenumber' and 'tabstop' don't change any
+        " currently tracked state. let's just always update on OptionSet.
+        let w:context.needs_update = 1
+    endif
+
     if 0
                 \ || !s:activated
                 \ || s:ignore_update
@@ -113,6 +119,7 @@ function! context#update(...) abort
     endif
 
     if !w:context.needs_update && !w:context.needs_layout
+        " call context#util#echof('> context#update (nothing to do)', source)
         return
     endif
 

--- a/autoload/context.vim
+++ b/autoload/context.vim
@@ -103,6 +103,7 @@ function! context#update(...) abort
                 \ || &previewwindow
                 \ || mode() != 'n'
                 \ || !context#util#active()
+                \ || bufname() =~# '^term://'
         let w:context.needs_update = 0
         " NOTE: we still consider needs_layout even if this buffer is disabled
     endif

--- a/autoload/context/context.vim
+++ b/autoload/context/context.vim
@@ -73,7 +73,7 @@ function! s:get_context_line(line) abort
     let skipped = get(b:context.skips, a:line.number, -1)
     if skipped != -1
         " call context#util#echof('  skipped', a:line.number, '->', skipped)
-        return context#line#make(skipped, g:context.Indent(skipped), getline(skipped))
+        return context#line#make(skipped, g:context.Indent(skipped), context#line#trim(getline(skipped)))
     endif
 
     " if line starts with closing brace or similar: jump to matching
@@ -105,13 +105,15 @@ function! s:get_context_line(line) abort
             continue
         endif
 
-        let line = getline(current_line)
-        if context#line#should_skip(line)
+        let text = getline(current_line)
+        " TODO: inject trimmed text into these functions? that way can
+        " probably simplify regexes too (don't need to handle leading spaces)
+        if context#line#should_skip(text)
             let current_line -= 1
             continue
         endif
 
-        return context#line#make(current_line, indent, line)
+        return context#line#make(current_line, indent, context#line#trim(text))
     endwhile
 endfunction
 

--- a/autoload/context/context.vim
+++ b/autoload/context/context.vim
@@ -106,8 +106,6 @@ function! s:get_context_line(line) abort
         endif
 
         let text = getline(current_line)
-        " TODO: inject trimmed text into these functions? that way can
-        " probably simplify regexes too (don't need to handle leading spaces)
         if context#line#should_skip(text)
             let current_line -= 1
             continue

--- a/autoload/context/context.vim
+++ b/autoload/context/context.vim
@@ -73,7 +73,7 @@ function! s:get_context_line(line) abort
     let skipped = get(b:context.skips, a:line.number, -1)
     if skipped != -1
         " call context#util#echof('  skipped', a:line.number, '->', skipped)
-        return context#line#make(skipped, g:context.Indent(skipped), context#line#trim(getline(skipped)))
+        return context#line#make_trimmed(skipped, g:context.Indent(skipped), getline(skipped))
     endif
 
     " if line starts with closing brace or similar: jump to matching
@@ -113,7 +113,7 @@ function! s:get_context_line(line) abort
             continue
         endif
 
-        return context#line#make(current_line, indent, context#line#trim(text))
+        return context#line#make_trimmed(current_line, indent, text)
     endwhile
 endfunction
 

--- a/autoload/context/line.vim
+++ b/autoload/context/line.vim
@@ -77,24 +77,33 @@ endfunction
 
 function! context#line#text(i, line) abort
     " TODO: do the same in border line
+    " TODO: for border line use number of lines hidden below bottom context
+    " line and topmost visible line? maybe with different highlight group?
 
     " sign column
-    let text = repeat(' ', w:context.sign_width)
+    let line = repeat(' ', w:context.sign_width)
 
     " number column
-    if w:context.number_width > 0
+    " TODO: remove special handling for 0 again
+    if a:line.number == 0
+        let line .= repeat(' ', w:context.number_width)
+    elseif w:context.number_width > 0
         if &relativenumber
             let n = w:context.cursor_line - a:line.number
         elseif &number
             let n = a:line.number
         endif
-        let text .= printf('%*d ', w:context.number_width - 1, n)
+        let line .= printf('%*d ', w:context.number_width - 1, n)
     endif
 
-    " text
-    let text .= a:line.text
+    " TODO: use `space` to fake tab listchars
+    let [_, space, text; _] = matchlist(a:line.text, '\v^(\s*)(.*)$')
 
-    return text
+    let line .= repeat(' ', a:line.indent)
+    " text
+    let line .= text
+
+    return line
 endfunction
 
 function! context#line#trim(string) abort

--- a/autoload/context/line.vim
+++ b/autoload/context/line.vim
@@ -76,7 +76,14 @@ function! s:join(lines) abort
 endfunction
 
 function! context#line#text(i, line) abort
-    return a:line.text
+    " TODO: do the same in border line
+    if &relativenumber
+        return printf('%*s%*d %s', w:context.sign_width, '', w:context.number_width - 1, w:context.cursor_line - a:line.number, a:line.text)
+    elseif &number
+        return printf('%*s%*d %s', w:context.sign_width, '', w:context.number_width - 1, a:line.number, a:line.text)
+    else
+        return printf('%*s%s', w:context.sign_width, '', a:line.text)
+    endif
 endfunction
 
 function! context#line#trim(string) abort

--- a/autoload/context/line.vim
+++ b/autoload/context/line.vim
@@ -1,8 +1,19 @@
 function! context#line#make(number, indent, text) abort
     return {
-                \ 'number': a:number,
-                \ 'indent': a:indent,
-                \ 'text':   a:text,
+                \ 'number':       a:number,
+                \ 'indent':       a:indent,
+                \ 'indent_chars': a:indent,
+                \ 'text':         a:text,
+                \ }
+endfunction
+
+function! context#line#make_trimmed(number, indent, text) abort
+    let trimmed_text = context#line#trim(a:text)
+    return {
+                \ 'number':       a:number,
+                \ 'indent':       a:indent,
+                \ 'indent_chars': len(a:text) - len(trimmed_text),
+                \ 'text':         trimmed_text,
                 \ }
 endfunction
 

--- a/autoload/context/line.vim
+++ b/autoload/context/line.vim
@@ -1,12 +1,12 @@
 function! context#line#make(number, indent, text) abort
-    return context#line#make_highlight(a:number, 0, a:indent, a:text, '')
+    return context#line#make_highlight(a:number, -1, a:indent, a:text, '')
 endfunction
 
 function! context#line#make_trimmed(number, indent, text) abort
     let trimmed_text = context#line#trim(a:text)
     return {
                 \ 'number':         a:number,
-                \ 'display_number': 0,
+                \ 'display_number': -1,
                 \ 'indent':         a:indent,
                 \ 'indent_chars':   len(a:text) - len(trimmed_text),
                 \ 'text':           trimmed_text,
@@ -74,13 +74,13 @@ function! s:join(lines) abort
     elseif max == 2
         " TODO: add vars for ellipsis lines?
         let text = ' ' . g:context.ellipsis
-        return [a:lines[0], context#line#make_highlight(0, 0, 0, text, 'Comment')]
+        return [a:lines[0], context#line#make_highlight(0, -1, 0, text, 'Comment')]
     endif
 
     if len(a:lines) > max " too many parts
         let text = ' ' . g:context.ellipsis5 . ' '
         call remove(a:lines, (max+1)/2, -max/2-1)
-        call insert(a:lines, context#line#make_highlight(0, 0, 0, text, 'Comment'), (max+1)/2) " middle marker
+        call insert(a:lines, context#line#make_highlight(0, -1, 0, text, 'Comment'), (max+1)/2) " middle marker
     endif
 
     " insert ellipses where there are gaps between the parts
@@ -90,7 +90,7 @@ function! s:join(lines) abort
         if n1 > 0 && n2 > 0
             " show ellipsis if line i+1 is not directly below line i
             let text = n2 > n1 + 1 ? ' ' . g:context.ellipsis . ' ' : ' '
-            call insert(a:lines, context#line#make_highlight(0, 0, 0, text, 'Comment'), i+1)
+            call insert(a:lines, context#line#make_highlight(0, -1, 0, text, 'Comment'), i+1)
         endif
         let i += 1
     endwhile
@@ -109,13 +109,10 @@ function! context#line#text(lines) abort
 
     " number column
     if w:context.number_width > 0
-        if a:lines[0].display_number != 0
+        if a:lines[0].display_number >= 0
             " NOTE: we align to the left here, similar to what Vim does when both
             " 'nmuber' and 'relativenumber' are set
             let text .= printf('%-*d ', w:context.number_width - 1, a:lines[0].display_number)
-        " TODO: remove special handling for 0 again
-        elseif a:lines[0].number == 0
-            let text .= repeat(' ', w:context.number_width)
         else
             if &relativenumber
                 let n = w:context.cursor_line - a:lines[0].number

--- a/autoload/context/line.vim
+++ b/autoload/context/line.vim
@@ -57,26 +57,21 @@ function! s:join(lines) abort
         return [a:lines[0], context#line#make(0, 0, g:context.ellipsis)]
     endif
 
-    if len(a:lines) > max
+    if len(a:lines) > max " too many parts
         call remove(a:lines, (max+1)/2, -max/2-1)
         call insert(a:lines, context#line#make(0, 0, g:context.ellipsis5), (max+1)/2) " middle marker
     endif
 
-    " TODO: remove
-    " let last_number = a:lines[0].number
-    " for line in a:lines[1:]
-    "     let joined.text .= ' '
-    "     if line.number == 0
-    "         " this is the middle marker, use long ellipsis
-    "         let joined.text .= g:context.ellipsis5
-    "     elseif last_number != 0 && line.number != last_number + 1
-    "         " not after middle marker and there are lines in between: show ellipsis
-    "         let joined.text .= g:context.ellipsis . ' '
-    "     endif
-
-    "     let joined.text .= context#line#trim(line.text)
-    "     let last_number = line.number
-    " endfor
+    " insert ellipses where there are gaps between the parts
+    let i = 0
+    while i < len(a:lines) - 1
+        let [n1, n2] = [a:lines[i].number, a:lines[i+1].number]
+        if n1 > 0 && n2 > 0 && n2 > n1 + 1
+            " line i+1 is not directly below line i, so add a marker
+            call insert(a:lines, context#line#make(0, 0, g:context.ellipsis), i+1)
+        endif
+        let i += 1
+    endwhile
 
     return a:lines
 endfunction

--- a/autoload/context/line.vim
+++ b/autoload/context/line.vim
@@ -17,13 +17,13 @@ function! context#line#get_base_line(line) abort
             return s:nil_line
         endif
 
-        let line = getline(current_line)
-        if context#line#should_skip(line)
+        let text = getline(current_line)
+        if context#line#should_skip(text)
             let current_line += 1
             continue
         endif
 
-        return context#line#make(current_line, indent, line)
+        return context#line#make(current_line, indent, text)
     endwhile
 endfunction
 

--- a/autoload/context/line.vim
+++ b/autoload/context/line.vim
@@ -83,6 +83,14 @@ function! context#line#display(winid, join_parts) abort
                 let n = c.cursor_line - part0.number
             elseif &number
                 let n = part0.number
+            else
+                " NOTE: this is unexpected, but can happen because of a neovim
+                " bug, see neovim#11878
+                " to reproduce open a file with visible context, then invoke
+                " fzf preview window (which activates context.vim based on the
+                " context window contents (which is already very unexpected)
+                " in a confusing way)
+                let n = 0
             endif
             " let part = printf('%*d ', width - 1, n)
             let part = repeat(' ', width-len(n)-1) . n . ' '

--- a/autoload/context/line.vim
+++ b/autoload/context/line.vim
@@ -1,13 +1,12 @@
 function! context#line#make(number, indent, text) abort
-    return context#line#make_highlight(a:number, -1, ' ', a:indent, a:text, '')
+    return context#line#make_highlight(a:number, '', a:indent, a:text, '')
 endfunction
 
 function! context#line#make_trimmed(number, indent, text) abort
     let trimmed_text = context#line#trim(a:text)
     return {
                 \ 'number':         a:number,
-                \ 'display_number': -1,
-                \ 'number_char':    ' ',
+                \ 'number_char':    '',
                 \ 'indent':         a:indent,
                 \ 'indent_chars':   len(a:text) - len(trimmed_text),
                 \ 'text':           trimmed_text,
@@ -15,10 +14,9 @@ function! context#line#make_trimmed(number, indent, text) abort
                 \ }
 endfunction
 
-function! context#line#make_highlight(number, display_number, number_char, indent, text, highlight) abort
+function! context#line#make_highlight(number, number_char, indent, text, highlight) abort
     return {
                 \ 'number':         a:number,
-                \ 'display_number': a:display_number,
                 \ 'number_char':    a:number_char,
                 \ 'indent':         a:indent,
                 \ 'indent_chars':   a:indent,
@@ -76,13 +74,13 @@ function! s:join(lines) abort
     elseif max == 2
         " TODO: add vars for ellipsis lines?
         let text = ' ' . g:context.ellipsis
-        return [a:lines[0], context#line#make_highlight(0, -1, ' ', 0, text, 'Comment')]
+        return [a:lines[0], context#line#make_highlight(0, '', 0, text, 'Comment')]
     endif
 
     if len(a:lines) > max " too many parts
         let text = ' ' . g:context.ellipsis5 . ' '
         call remove(a:lines, (max+1)/2, -max/2-1)
-        call insert(a:lines, context#line#make_highlight(0, -1, ' ', 0, text, 'Comment'), (max+1)/2) " middle marker
+        call insert(a:lines, context#line#make_highlight(0, '', 0, text, 'Comment'), (max+1)/2) " middle marker
     endif
 
     " insert ellipses where there are gaps between the parts
@@ -92,7 +90,7 @@ function! s:join(lines) abort
         if n1 > 0 && n2 > 0
             " show ellipsis if line i+1 is not directly below line i
             let text = n2 > n1 + 1 ? ' ' . g:context.ellipsis . ' ' : ' '
-            call insert(a:lines, context#line#make_highlight(0, -1, ' ', 0, text, 'Comment'), i+1)
+            call insert(a:lines, context#line#make_highlight(0, '', 0, text, 'Comment'), i+1)
         endif
         let i += 1
     endwhile
@@ -132,10 +130,7 @@ function! context#line#display(join_parts) abort
     " number column
     let width = c.number_width
     if width > 0
-        if part0.display_number >= 0
-            " NOTE: we align to the left here, similar to what Vim does when both
-            " 'nmuber' and 'relativenumber' are set
-            " let part = printf('%-*d ', width - 1, part0.display_number)
+        if part0.number_char != ''
             " NOTE: we use a non breaking space here because number_char can
             " be border_char
             let part = repeat(part0.number_char, width-1) . ' '

--- a/autoload/context/line.vim
+++ b/autoload/context/line.vim
@@ -119,11 +119,16 @@ function! context#line#display(join_parts) abort
     "     return [text, highlights]
     " endif
 
+    " NOTE: we use non breaking spaces for padding in order to not show
+    " 'listchars' in the sign and number columns
+
     " sign column
     let width = c.sign_width
     if width > 0
-        let text .= repeat(' ', width)
+        let part = repeat(' ', width)
+        let width = len(part)
         call add(highlights, ['SignColumn', col, width])
+        let text .= part
         let col += width
     endif
 
@@ -140,7 +145,8 @@ function! context#line#display(join_parts) abort
             elseif &number
                 let n = part0.number
             endif
-            let part = printf('%*d ', width - 1, n)
+            " let part = printf('%*d ', width - 1, n)
+            let part = repeat(' ', width-len(n)-1) . n . ' '
         endif
 
         let width = len(part)

--- a/autoload/context/line.vim
+++ b/autoload/context/line.vim
@@ -76,7 +76,7 @@ function! s:join(lines) abort
     return a:lines
 endfunction
 
-function! context#line#text(i, lines) abort
+function! context#line#text(lines) abort
     " TODO: do the same in border line
     " TODO: for border line use number of lines hidden below bottom context
     " line and topmost visible line? maybe with different highlight group?

--- a/autoload/context/line.vim
+++ b/autoload/context/line.vim
@@ -106,11 +106,7 @@ function! context#line#display(winid, join_parts) abort
     let highlights = []
     let part0 = a:join_parts[0]
 
-    let c = getwinvar(a:winid, 'context', {})
-    if c == {}
-        " TODO: can this happen? do we need this check?
-        return [text, highlights]
-    endif
+    let c = getwinvar(a:winid, 'context')
 
     " NOTE: we use non breaking spaces for padding in order to not show
     " 'listchars' in the sign and number columns
@@ -151,9 +147,15 @@ function! context#line#display(winid, join_parts) abort
     " indent
     " TODO: use `space` to fake tab listchars?
     " let [_, space, text; _] = matchlist(part0.text, '\v^(\s*)(.*)$')
-    let part = repeat(' ', part0.indent)
-    let text .= part
-    let col += len(part)
+    if part0.indent > 0
+        let part = repeat(' ', part0.indent)
+        let width = len(part)
+        " NOTE: this highlight wouldn't be necessary for popup, but is added
+        " to make it easier to assemble the statusline for preview
+        call add(highlights, ['Normal', col, width])
+        let text .= part
+        let col += width
+    endif
 
     " text
     let prev_hl = ''

--- a/autoload/context/line.vim
+++ b/autoload/context/line.vim
@@ -58,17 +58,19 @@ function! s:join(lines) abort
     endif
 
     if len(a:lines) > max " too many parts
+        let text = ' ' . g:context.ellipsis5 . ' '
         call remove(a:lines, (max+1)/2, -max/2-1)
-        call insert(a:lines, context#line#make(0, 0, g:context.ellipsis5), (max+1)/2) " middle marker
+        call insert(a:lines, context#line#make(0, 0, text), (max+1)/2) " middle marker
     endif
 
     " insert ellipses where there are gaps between the parts
     let i = 0
     while i < len(a:lines) - 1
         let [n1, n2] = [a:lines[i].number, a:lines[i+1].number]
-        if n1 > 0 && n2 > 0 && n2 > n1 + 1
-            " line i+1 is not directly below line i, so add a marker
-            call insert(a:lines, context#line#make(0, 0, g:context.ellipsis), i+1)
+        if n1 > 0 && n2 > 0
+            " show ellipsis if line i+1 is not directly below line i
+            let text = n2 > n1 + 1 ? ' ' . g:context.ellipsis . ' ' : ' '
+            call insert(a:lines, context#line#make(0, 0, text), i+1)
         endif
         let i += 1
     endwhile
@@ -76,8 +78,9 @@ function! s:join(lines) abort
     return a:lines
 endfunction
 
+" TODO: have a single function going through the join parts once and returning
+" the joined text and the highlight groups?
 function! context#line#text(lines) abort
-    " TODO: do the same in border line
     " TODO: for border line use number of lines hidden below bottom context
     " line and topmost visible line? maybe with different highlight group?
 
@@ -103,11 +106,8 @@ function! context#line#text(lines) abort
     let text .= repeat(' ', a:lines[0].indent)
 
     " text
-    for i in range(0, len(a:lines) - 1)
-        if i > 0
-            let text .= ' '
-        endif
-        let text .=  context#line#trim(a:lines[i].text)
+    for line in a:lines
+        let text .= line.text
     endfor
 
     return text

--- a/autoload/context/line.vim
+++ b/autoload/context/line.vim
@@ -174,13 +174,13 @@ function! context#line#display(join_parts) abort
         " call add(highlights, [hl, col, width])
         " let col += width
 
-        let count = 0
+        let width = 0
 
         if join_part.highlight != ''
-            let count = len(join_part.text)
-            call add(highlights, [join_part.highlight, col, count])
-            let col += count
-            let count = 1
+            let width = len(join_part.text)
+            call add(highlights, [join_part.highlight, col, width])
+            let col += width
+            let width = 1
             continue
         endif
 
@@ -188,19 +188,19 @@ function! context#line#display(join_parts) abort
             let hlgroup = synIDattr(synIDtrans(synID(join_part.number, line_col, 1)), 'name')
 
             if hlgroup == prev_hl " TODO: add col < end condition?
-                let count += 1
+                let width += 1
                 continue
             endif
 
             if prev_hl != ''
-                call add(highlights, [prev_hl, col, count])
+                call add(highlights, [prev_hl, col, width])
             endif
 
             let prev_hl = hlgroup
-            let col += count
-            let count = 1
+            let col += width
+            let width = 1
         endfor
-        let col += count-1
+        let col += width-1
     endfor
 
     return [text, highlights]

--- a/autoload/context/line.vim
+++ b/autoload/context/line.vim
@@ -46,58 +46,6 @@ function! context#line#get_base_line(line) abort
     endwhile
 endfunction
 
-function! context#line#join(batch) abort
-    return s:join(a:batch)
-
-    " TODO: clean up/inline
-    let line = a:batch[0]
-    let text = s:join(a:batch)
-
-    " TODO: where should this debug output go now?
-    " let n = &columns - 30 - strchars(context#line#trim(text)) - line.indent
-    " let text = printf('%s%s // %2d n:%5d i:%2d', text, repeat(' ', n), len(a:batch), line.number, line.indent)
-
-    return context#line#make(line.number, line.indent, text)
-endfunction
-
-" TODO: rename? doesn't really join now, but just enforce max_join_parts
-function! s:join(lines) abort
-    " call context#util#echof('> join', len(a:lines))
-    if len(a:lines) == 1
-        return a:lines
-    endif
-
-    let max = g:context.max_join_parts
-
-    if max == 1
-        return [a:lines[0]]
-    elseif max == 2
-        " TODO: add vars for ellipsis lines?
-        let text = ' ' . g:context.ellipsis
-        return [a:lines[0], context#line#make_highlight(0, '', 0, text, 'Comment')]
-    endif
-
-    if len(a:lines) > max " too many parts
-        let text = ' ' . g:context.ellipsis5 . ' '
-        call remove(a:lines, (max+1)/2, -max/2-1)
-        call insert(a:lines, context#line#make_highlight(0, '', 0, text, 'Comment'), (max+1)/2) " middle marker
-    endif
-
-    " insert ellipses where there are gaps between the parts
-    let i = 0
-    while i < len(a:lines) - 1
-        let [n1, n2] = [a:lines[i].number, a:lines[i+1].number]
-        if n1 > 0 && n2 > 0
-            " show ellipsis if line i+1 is not directly below line i
-            let text = n2 > n1 + 1 ? ' ' . g:context.ellipsis . ' ' : ' '
-            call insert(a:lines, context#line#make_highlight(0, '', 0, text, 'Comment'), i+1)
-        endif
-        let i += 1
-    endwhile
-
-    return a:lines
-endfunction
-
 " returns list of [line, [highlights]]
 " where each highlight is [hl, col, width]
 function! context#line#display(winid, join_parts) abort

--- a/autoload/context/line.vim
+++ b/autoload/context/line.vim
@@ -71,13 +71,14 @@ function! s:join(lines) abort
         return [a:lines[0]]
     elseif max == 2
         " TODO: add vars for ellipsis lines?
-        return [a:lines[0], context#line#make(0, 0, g:context.ellipsis)]
+        let text = ' ' . g:context.ellipsis
+        return [a:lines[0], context#line#make_highlight(0, 0, text, 'Comment')]
     endif
 
     if len(a:lines) > max " too many parts
         let text = ' ' . g:context.ellipsis5 . ' '
         call remove(a:lines, (max+1)/2, -max/2-1)
-        call insert(a:lines, context#line#make(0, 0, text), (max+1)/2) " middle marker
+        call insert(a:lines, context#line#make_highlight(0, 0, text, 'Comment'), (max+1)/2) " middle marker
     endif
 
     " insert ellipses where there are gaps between the parts
@@ -87,7 +88,7 @@ function! s:join(lines) abort
         if n1 > 0 && n2 > 0
             " show ellipsis if line i+1 is not directly below line i
             let text = n2 > n1 + 1 ? ' ' . g:context.ellipsis . ' ' : ' '
-            call insert(a:lines, context#line#make(0, 0, text), i+1)
+            call insert(a:lines, context#line#make_highlight(0, 0, text, 'Comment'), i+1)
         endif
         let i += 1
     endwhile
@@ -95,7 +96,7 @@ function! s:join(lines) abort
     return a:lines
 endfunction
 
-" TODO: have a single function going through the join parts once and returning
+" TODO!: have a single function going through the join parts once and returning
 " the joined text and the highlight groups?
 function! context#line#text(lines) abort
     " TODO: for border line use number of lines hidden below bottom context

--- a/autoload/context/line.vim
+++ b/autoload/context/line.vim
@@ -1,10 +1,5 @@
 function! context#line#make(number, indent, text) abort
-    return {
-                \ 'number':       a:number,
-                \ 'indent':       a:indent,
-                \ 'indent_chars': a:indent,
-                \ 'text':         a:text,
-                \ }
+    return context#line#make_highlight(a:number, a:indent, a:text, '')
 endfunction
 
 function! context#line#make_trimmed(number, indent, text) abort
@@ -14,6 +9,17 @@ function! context#line#make_trimmed(number, indent, text) abort
                 \ 'indent':       a:indent,
                 \ 'indent_chars': len(a:text) - len(trimmed_text),
                 \ 'text':         trimmed_text,
+                \ 'highlight':    '',
+                \ }
+endfunction
+
+function! context#line#make_highlight(number, indent, text, highlight) abort
+    return {
+                \ 'number':       a:number,
+                \ 'indent':       a:indent,
+                \ 'indent_chars': a:indent,
+                \ 'text':         a:text,
+                \ 'highlight':    a:highlight,
                 \ }
 endfunction
 

--- a/autoload/context/line.vim
+++ b/autoload/context/line.vim
@@ -49,7 +49,6 @@ endfunction
 " returns list of [line, [highlights]]
 " where each highlight is [hl, col, width]
 function! context#line#display(winid, join_parts) abort
-    let col = 1 " TODO: can we infer this from len(text) or something?
     let text = ''
     let highlights = []
     let part0 = a:join_parts[0]
@@ -64,9 +63,8 @@ function! context#line#display(winid, join_parts) abort
     if width > 0
         let part = repeat(' ', width)
         let width = len(part)
-        call add(highlights, ['SignColumn', col, width])
+        call add(highlights, ['SignColumn', len(text), width])
         let text .= part
-        let col += width
     endif
 
     " number column
@@ -87,9 +85,8 @@ function! context#line#display(winid, join_parts) abort
         endif
 
         let width = len(part)
-        call add(highlights, ['LineNr', col, width])
+        call add(highlights, ['LineNr', len(text), width])
         let text .= part
-        let col += width
     endif
 
     " indent
@@ -100,10 +97,14 @@ function! context#line#display(winid, join_parts) abort
         let width = len(part)
         " NOTE: this highlight wouldn't be necessary for popup, but is added
         " to make it easier to assemble the statusline for preview
-        call add(highlights, ['Normal', col, width])
+        call add(highlights, ['Normal', len(text), width])
         let text .= part
-        let col += width
     endif
+
+    " NOTE: below 'col' and 'len(text)' diverge because we add the text in one
+    " big chunk but go through the highlights character by character to find
+    " the highlight chunks
+    let col = len(text)
 
     " text
     let prev_hl = ''
@@ -116,6 +117,7 @@ function! context#line#display(winid, join_parts) abort
         " let hl = j % 2 == 0 ? 'Search' : 'IncSearch'
         " call add(highlights, [hl, col, width])
         " let col += width
+        " continue
 
         let width = 0
 

--- a/autoload/context/line.vim
+++ b/autoload/context/line.vim
@@ -77,13 +77,24 @@ endfunction
 
 function! context#line#text(i, line) abort
     " TODO: do the same in border line
-    if &relativenumber
-        return printf('%*s%*d %s', w:context.sign_width, '', w:context.number_width - 1, w:context.cursor_line - a:line.number, a:line.text)
-    elseif &number
-        return printf('%*s%*d %s', w:context.sign_width, '', w:context.number_width - 1, a:line.number, a:line.text)
-    else
-        return printf('%*s%s', w:context.sign_width, '', a:line.text)
+
+    " sign column
+    let text = repeat(' ', w:context.sign_width)
+
+    " number column
+    if w:context.number_width > 0
+        if &relativenumber
+            let n = w:context.cursor_line - a:line.number
+        elseif &number
+            let n = a:line.number
+        endif
+        let text .= printf('%*d ', w:context.number_width - 1, n)
     endif
+
+    " text
+    let text .= a:line.text
+
+    return text
 endfunction
 
 function! context#line#trim(string) abort

--- a/autoload/context/line.vim
+++ b/autoload/context/line.vim
@@ -100,24 +100,17 @@ endfunction
 
 " returns list of [line, [highlights]]
 " where each highlight is [hl, col, width]
-function! context#line#display(join_parts) abort
+function! context#line#display(winid, join_parts) abort
     let col = 1 " TODO: can we infer this from len(text) or something?
     let text = ''
     let highlights = []
     let part0 = a:join_parts[0]
 
-    " TODO: remove and use the below instead. we then probably need to call
-    " #display again from context#popup#layout with injected winid. but test
-    " this first, make sure this is actually needed (probably is), have
-    " multiple windows, some with sign/number columns others without and then
-    " trigger layout or similar
-    let c = w:context
-
-    " let c = getwinvar(a:winid, 'context', {})
-    " if c == {}
-    "     " TODO: can this happen? do we need this check?
-    "     return [text, highlights]
-    " endif
+    let c = getwinvar(a:winid, 'context', {})
+    if c == {}
+        " TODO: can this happen? do we need this check?
+        return [text, highlights]
+    endif
 
     " NOTE: we use non breaking spaces for padding in order to not show
     " 'listchars' in the sign and number columns

--- a/autoload/context/popup.vim
+++ b/autoload/context/popup.vim
@@ -195,7 +195,7 @@ function! s:open() abort
     call matchadd(g:context.highlight_tag,    tag,    10, -1, {'window': popup})
 
     let buf = winbufnr(popup)
-    call setbufvar(buf, '&syntax', &syntax)
+    " call setbufvar(buf, '&syntax', &syntax)
 
     return popup
 endfunction

--- a/autoload/context/popup.vim
+++ b/autoload/context/popup.vim
@@ -96,6 +96,8 @@ endfunction
 
 function! context#popup#redraw(winid) abort
     let popup = get(g:context.popups, a:winid)
+    call context#util#echof('> context#popup#redraw', a:winid, popup)
+
     if popup == 0
         return
     endif

--- a/autoload/context/popup.vim
+++ b/autoload/context/popup.vim
@@ -170,7 +170,7 @@ function! context#popup#redraw(winid) abort
         let count = 0
         for join_part in lines[l]
             " call context#util#echof('join_part', l, len(join_part.text) + 1)
-            for line_col in range(1+join_part.indent, join_part.indent + len(join_part.text)+1) " TODO: only up to windowwidth
+            for line_col in range(1+join_part.indent_chars, join_part.indent_chars + len(join_part.text)+1) " TODO: only up to windowwidth
                 let hlgroup = synIDattr(synIDtrans(synID(join_part.number, line_col, 1)), 'name')
                 " call context#util#echof('hlgroup', l, line_col, hlgroup)
 

--- a/autoload/context/popup.vim
+++ b/autoload/context/popup.vim
@@ -119,7 +119,7 @@ function! context#popup#redraw(winid) abort
     let display_lines = []
     let hls = [] " list of lists, one per context line
     for line in lines
-        let [text, highlights] = context#line#display(line)
+        let [text, highlights] = context#line#display(a:winid, line)
         call context#util#echof('highlights', text, highlights)
         call add(display_lines, text)
         call add(hls, highlights)
@@ -209,9 +209,6 @@ function! s:open() abort
     call matchadd(g:context.highlight_border, border, 10, -1, {'window': popup})
     call matchadd(g:context.highlight_tag,    tag,    10, -1, {'window': popup})
 
-    let buf = winbufnr(popup)
-    " call setbufvar(buf, '&syntax', &syntax)
-
     return popup
 endfunction
 
@@ -240,6 +237,9 @@ function! s:get_border_line(winid, indent) abort
     let border_char = g:context.char_border
     if g:context.show_tag
         let line_len -= len(s:context_buffer_name) + 1
+        " TODO: maybe we can move this calculation to #line#render?
+        " so we could reuse the context lines even if the width has changed?
+        " might not be worth it, but maybe consider
         let border_text = repeat(g:context.char_border, line_len)
         " here the NB space belongs to the tag part (for minor highlighting reasons)
         let tag_text = ' ' . s:context_buffer_name . ' '

--- a/autoload/context/popup.vim
+++ b/autoload/context/popup.vim
@@ -134,7 +134,7 @@ function! context#popup#redraw(winid) abort
     let args = {'window': popup}
     for h in range(0, len(hls)-1)
         for hl in hls[h]
-            call matchaddpos(hl[0], [[h+1, hl[1], hl[2]]], 10, -1, args)
+            call matchaddpos(hl[0], [[h+1, hl[1]+1, hl[2]]], 10, -1, args)
         endfor
     endfor
 endfunction

--- a/autoload/context/popup.vim
+++ b/autoload/context/popup.vim
@@ -125,6 +125,20 @@ function! context#popup#redraw(winid) abort
     elseif g:context.presenter == 'vim-popup'
         call context#popup#vim#redraw(a:winid, popup, lines)
     endif
+
+    for i in range(1, len(lines))
+        let n = 1
+        " TODO: seems like we need to handle the case where w:context doesn't
+        " exist. do we have a bug somewhere? try open normal.c, split window,
+        " change with fzf (probably the fzf popup issue again...)
+        let m = w:context.sign_width
+        call matchaddpos('SignColumn', [[i,n,m]], 10, -1, {'window': popup})
+        if w:context.number_width > 0
+            let n += m
+            let m = w:context.number_width
+            call matchaddpos('LineNr', [[i,n,m]], 10, -1, {'window': popup})
+        endif
+    endfor
 endfunction
 
 " close all popups
@@ -180,6 +194,8 @@ function! s:show() abort
     endif
 endfunction
 
+" TODO: consider fold column too
+
 function! s:open() abort
     call context#util#echof('  > open')
     if g:context.presenter == 'nvim-float'
@@ -191,6 +207,7 @@ function! s:open() abort
     " NOTE: we use a non breaking space here again before the buffer name
     let border = ' *' .g:context.char_border . '* '
     let tag = s:context_buffer_name
+    " TODO: remove these
     call matchadd(g:context.highlight_border, border, 10, -1, {'window': popup})
     call matchadd(g:context.highlight_tag,    tag,    10, -1, {'window': popup})
 

--- a/autoload/context/popup.vim
+++ b/autoload/context/popup.vim
@@ -127,16 +127,24 @@ function! context#popup#redraw(winid) abort
     endif
 
     for i in range(1, len(lines))
-        let n = 1
         " TODO: seems like we need to handle the case where w:context doesn't
         " exist. do we have a bug somewhere? try open normal.c, split window,
         " change with fzf (probably the fzf popup issue again...)
-        let m = w:context.sign_width
-        call matchaddpos('SignColumn', [[i,n,m]], 10, -1, {'window': popup})
-        if w:context.number_width > 0
+        let n = 1
+        let m = 0
+
+        let d = w:context.sign_width
+        if d > 0
+            let m += d
+            call matchaddpos('SignColumn', [[i,n,m]], 10, -1, {'window': popup})
             let n += m
+        endif
+
+        let d = w:context.number_width
+        if d > 0
             let m = w:context.number_width
             call matchaddpos('LineNr', [[i,n,m]], 10, -1, {'window': popup})
+            let n += m
         endif
     endfor
 endfunction

--- a/autoload/context/popup.vim
+++ b/autoload/context/popup.vim
@@ -237,18 +237,19 @@ function! s:get_border_line(winid, indent) abort
     " can be some display issues in the Kitty terminal with a normal space
 
     let line_len = c.size_w - c.padding - indent - 1
+    let border_char = g:context.char_border
     if g:context.show_tag
         let line_len -= len(s:context_buffer_name) + 1
         let border_text = repeat(g:context.char_border, line_len)
         " here the NB space belongs to the tag part (for minor highlighting reasons)
         let tag_text = ' ' . s:context_buffer_name . ' '
         return [
-                    \ context#line#make_highlight(0, n, indent, border_text, g:context.highlight_border),
-                    \ context#line#make_highlight(0, n, indent, tag_text,    g:context.highlight_tag)
+                    \ context#line#make_highlight(0, n, border_char, indent, border_text, g:context.highlight_border),
+                    \ context#line#make_highlight(0, n, border_char, indent, tag_text,    g:context.highlight_tag)
                     \ ]
     endif
 
     " here the NB space belongs to the border part
     let border_text = repeat(g:context.char_border, line_len) . ' '
-    return [context#line#make_highlight(0, n, indent, border_text, g:context.highlight_border)]
+    return [context#line#make_highlight(0, n, border_char, indent, border_text, g:context.highlight_border)]
 endfunction

--- a/autoload/context/popup.vim
+++ b/autoload/context/popup.vim
@@ -244,12 +244,12 @@ function! s:get_border_line(winid, indent) abort
         " here the NB space belongs to the tag part (for minor highlighting reasons)
         let tag_text = ' ' . s:context_buffer_name . ' '
         return [
-                    \ context#line#make_highlight(0, n, border_char, indent, border_text, g:context.highlight_border),
-                    \ context#line#make_highlight(0, n, border_char, indent, tag_text,    g:context.highlight_tag)
+                    \ context#line#make_highlight(0, border_char, indent, border_text, g:context.highlight_border),
+                    \ context#line#make_highlight(0, border_char, indent, tag_text,    g:context.highlight_tag)
                     \ ]
     endif
 
     " here the NB space belongs to the border part
     let border_text = repeat(g:context.char_border, line_len) . ' '
-    return [context#line#make_highlight(0, n, border_char, indent, border_text, g:context.highlight_border)]
+    return [context#line#make_highlight(0, border_char, indent, border_text, g:context.highlight_border)]
 endfunction

--- a/autoload/context/popup.vim
+++ b/autoload/context/popup.vim
@@ -146,7 +146,8 @@ function! context#popup#redraw(winid) abort
 
         let width = c.number_width
         if width > 0
-            call matchaddpos('LineNr', [[l+1, col, width]], 10, -1, {'window': popup})
+            let hl = lines[l][0].display_number == 0 ? 'LineNr' : 'CursorLineNr'
+            call matchaddpos(hl, [[l+1, col, width]], 10, -1, {'window': popup})
             let col += width
         endif
 
@@ -301,12 +302,12 @@ function! s:get_border_line(winid, indent) abort
         " here the NB space belongs to the tag part (for minor highlighting reasons)
         let tag_text = ' ' . s:context_buffer_name . ' '
         return [
-                    \ context#line#make_highlight(0, indent, border_text, g:context.highlight_border),
-                    \ context#line#make_highlight(0, indent, tag_text, g:context.highlight_tag)
+                    \ context#line#make_highlight(0, 0, indent, border_text, g:context.highlight_border),
+                    \ context#line#make_highlight(0, 0, indent, tag_text,    g:context.highlight_tag)
                     \ ]
     endif
 
     " here the NB space belongs to the border part
     let border_text = repeat(g:context.char_border, line_len) . ' '
-    return [context#line#make_highlight(0, indent, border_text, g:context.highlight_border)]
+    return [context#line#make_highlight(0, 0, indent, border_text, g:context.highlight_border)]
 endfunction

--- a/autoload/context/popup.vim
+++ b/autoload/context/popup.vim
@@ -7,7 +7,7 @@ function! context#popup#update_context() abort
     let w:context.lines  = lines
     let w:context.indent = g:context.Border_indent(base_line)
 
-    call context#util#show_cursor()
+    call s:show_cursor()
     call s:show()
 endfunction
 
@@ -162,7 +162,21 @@ function! context#popup#close() abort
     call remove(g:context.popups, winid)
 endfunction
 
-" popup related
+function! s:show_cursor() abort
+    " compare height of context to cursor line on screen
+    let n = len(w:context.lines) + g:context.show_border - (w:context.cursor_line - w:context.top_line)
+    if n <= 0
+        " if cursor is low enough, nothing to do
+        return
+    end
+
+    " otherwise we have to either move or scroll the cursor accordingly
+    " call context#util#echof('show_cursor', w:context.fix_strategy, n)
+    let key = (w:context.fix_strategy == 'move') ? 'j' : "\<C-Y>"
+    execute 'normal! ' . n . key
+    call context#util#update_line_state()
+endfunction
+
 function! s:show() abort
     let winid = win_getid()
     let popup = get(g:context.popups, winid)

--- a/autoload/context/popup.vim
+++ b/autoload/context/popup.vim
@@ -36,7 +36,7 @@ function! context#popup#get_context() abort
         let text = getline(line_number) " empty for invalid lines
         if context#line#should_skip(text)
             let skipped += 1
-            call context#util#echof('skip', line_number)
+            " call context#util#echof('skip', line_number)
             continue
         endif
 

--- a/autoload/context/popup.vim
+++ b/autoload/context/popup.vim
@@ -219,16 +219,26 @@ function! s:get_border_line(winid, indent) abort
         let line_len -= len(s:context_buffer_name) + 1
     endif
 
+    let line = repeat(' ', w:context.sign_width)
+
+    " number column
+    " TODO: remove special handling for 0 again
+    if w:context.number_width > 0
+        " TODO: show number of hidden lines below last context line
+        let n = 0
+        let line .= printf('%*d ', w:context.number_width - 1, n)
+    endif
+
+    let line .= repeat(' ', indent)
+    let line .= repeat(g:context.char_border, line_len)
+
     " NOTE: we use a non breaking space before the buffer name because there
     " can be some display issues in the Kitty terminal with a normal space
-    let border_line = ''
-                \ . repeat(' ', indent)
-                \ . repeat(g:context.char_border, line_len)
-                \ . ' '
+    let line .= ' '
+
     if g:context.show_tag
-        let border_line .= ''
-                    \ . s:context_buffer_name
-                    \ . ' '
+        let line .= s:context_buffer_name . ' '
     endif
-    return border_line
+
+    return line
 endfunction

--- a/autoload/context/popup.vim
+++ b/autoload/context/popup.vim
@@ -120,7 +120,7 @@ function! context#popup#redraw(winid) abort
     let hls = [] " list of lists, one per context line
     for line in lines
         let [text, highlights] = context#line#display(a:winid, line)
-        call context#util#echof('highlights', text, highlights)
+        " call context#util#echof('highlights', text, highlights)
         call add(display_lines, text)
         call add(hls, highlights)
     endfor

--- a/autoload/context/popup.vim
+++ b/autoload/context/popup.vim
@@ -129,7 +129,6 @@ function! context#popup#redraw(winid) abort
 
     " TODO!: use better "line numbers" for special lines, maybe use
     " CursorLineNr as highlight group
-    " TODO!: add highlight for ellipsis? (as comment?)
 
     for l in range(0, len(lines) - 1)
         " TODO: seems like we need to handle the case where w:context doesn't
@@ -164,14 +163,16 @@ function! context#popup#redraw(winid) abort
         " continue
 
         let prev_hl = ''
-        let count = 0
         for join_part in lines[l]
+            let count = 0
             " call context#util#echof('join_part', l, len(join_part.text) + 1)
 
             if join_part.highlight != ''
                 let count = len(join_part.text)
+                call context#util#echof('adding hl1', join_part.highlight, l, col, count)
                 call matchaddpos(join_part.highlight, [[l+1, col, count]], 0, -1, {'window': popup})
                 let col += count
+                let count = 1
                 continue
             endif
 
@@ -189,13 +190,14 @@ function! context#popup#redraw(winid) abort
                 endif
 
                 if prev_hl != ''
-                    " call context#util#echof('adding hl', prev_hl, l, col, count)
+                    call context#util#echof('adding hl2', prev_hl, l, col, count)
                     call matchaddpos(prev_hl, [[l+1, col, count]], 0, -1, {'window': popup})
                 endif
                 let prev_hl = hlgroup
                 let col += count
                 let count = 1
             endfor
+            let col += count-1
         endfor
     endfor
 endfunction

--- a/autoload/context/popup/nvim.vim
+++ b/autoload/context/popup/nvim.vim
@@ -41,6 +41,8 @@ function! context#popup#nvim#redraw(winid, popup, lines) abort
     " NOTE: because of some neovim limitation we have to temporarily switch to
     " the popup window so we can clear the highlighting
     " https://github.com/neovim/neovim/issues/10822
+    " TODO: seems like this still triggers a BufEnter autocmd which triggers a
+    " context, stop that from happening
     execute 'noautocmd' bufwinnr(buf) . 'wincmd w'
     call clearmatches()
     wincmd p

--- a/autoload/context/popup/nvim.vim
+++ b/autoload/context/popup/nvim.vim
@@ -38,13 +38,10 @@ function! context#popup#nvim#redraw(winid, popup, lines) abort
 
     call setwinvar(a:popup, '&list', &list)
 
-    " TODO!: there's actually an issue now. try scolling or zt, sometimes the
-    " popup window remains active...
-
     " NOTE: because of some neovim limitation we have to temporarily switch to
     " the popup window so we can clear the highlighting
     " https://github.com/neovim/neovim/issues/10822
-    execute bufwinnr(buf) . "wincmd w"
+    execute 'noautocmd' bufwinnr(buf) . 'wincmd w'
     call clearmatches()
     wincmd p
 endfunction

--- a/autoload/context/popup/nvim.vim
+++ b/autoload/context/popup/nvim.vim
@@ -8,7 +8,7 @@ function! context#popup#nvim#open() abort
                 \ 'col':       0,
                 \ 'width':     1,
                 \ 'height':    1,
-                \ 'focusable': v:true,
+                \ 'focusable': v:false,
                 \ 'style':     'minimal',
                 \ })
 

--- a/autoload/context/popup/nvim.vim
+++ b/autoload/context/popup/nvim.vim
@@ -37,6 +37,16 @@ function! context#popup#nvim#redraw(winid, popup, lines) abort
                 \ })
 
     call setwinvar(a:popup, '&list', &list)
+
+    " TODO!: there's actually an issue now. try scolling or zt, sometimes the
+    " popup window remains active...
+
+    " NOTE: because of some neovim limitation we have to temporarily switch to
+    " the popup window so we can clear the highlighting
+    " https://github.com/neovim/neovim/issues/10822
+    execute bufwinnr(buf) . "wincmd w"
+    call clearmatches()
+    wincmd p
 endfunction
 
 function! context#popup#nvim#close(popup) abort

--- a/autoload/context/popup/nvim.vim
+++ b/autoload/context/popup/nvim.vim
@@ -15,8 +15,7 @@ function! context#popup#nvim#open() abort
     call setwinvar(popup, '&wrap', 0)
     call setwinvar(popup, '&foldenable', 0)
     call setwinvar(popup, '&tabstop', &tabstop)
-    call setwinvar(popup, '&winhighlight',
-                \ 'FoldColumn:Normal,Normal:' . g:context.highlight_normal)
+    call setwinvar(popup, '&winhighlight', 'Normal:' . g:context.highlight_normal)
 
     return popup
 endfunction

--- a/autoload/context/popup/nvim.vim
+++ b/autoload/context/popup/nvim.vim
@@ -8,7 +8,7 @@ function! context#popup#nvim#open() abort
                 \ 'col':       0,
                 \ 'width':     1,
                 \ 'height':    1,
-                \ 'focusable': v:false,
+                \ 'focusable': v:true,
                 \ 'style':     'minimal',
                 \ })
 
@@ -36,7 +36,7 @@ function! context#popup#nvim#redraw(winid, popup, lines) abort
                 \ 'width':    c.size_w,
                 \ })
 
-    call setwinvar(a:popup, '&foldcolumn', c.padding)
+    call setwinvar(a:popup, '&list', &list)
 endfunction
 
 function! context#popup#nvim#close(popup) abort

--- a/autoload/context/popup/nvim.vim
+++ b/autoload/context/popup/nvim.vim
@@ -50,8 +50,6 @@ function! context#popup#nvim#redraw(winid, popup, lines) abort
     " NOTE: because of some neovim limitation we have to temporarily switch to
     " the popup window so we can clear the highlighting
     " https://github.com/neovim/neovim/issues/10822
-    " TODO!: seems like this still triggers a BufEnter autocmd which triggers a
-    " context, stop that from happening
     execute 'noautocmd' bufwinnr(buf) . 'wincmd w'
     call clearmatches()
     wincmd p

--- a/autoload/context/popup/vim.vim
+++ b/autoload/context/popup/vim.vim
@@ -25,7 +25,6 @@ function! context#popup#vim#redraw(winid, popup, lines) abort
                 \ 'maxwidth': c.size_w,
                 \ })
 
-    " call win_execute(a:popup, 'let &foldcolumn=' . c.padding)
     call win_execute(a:popup, 'let &list=' . &list)
     call win_execute(a:popup, 'call clearmatches()')
 endfunction

--- a/autoload/context/popup/vim.vim
+++ b/autoload/context/popup/vim.vim
@@ -26,8 +26,9 @@ function! context#popup#vim#redraw(winid, popup, lines) abort
                 \ 'maxwidth': c.size_w,
                 \ })
 
-    call win_execute(a:popup, 'let &foldcolumn=' . c.padding)
+    " call win_execute(a:popup, 'let &foldcolumn=' . c.padding)
     call win_execute(a:popup, 'let &list=' . &list)
+    call win_execute(a:popup, 'call clearmatches()')
 endfunction
 
 function! context#popup#vim#close(popup) abort

--- a/autoload/context/popup/vim.vim
+++ b/autoload/context/popup/vim.vim
@@ -8,7 +8,6 @@ function! context#popup#vim#open() abort
                 \ })
 
     call setwinvar(popup, '&wincolor', g:context.highlight_normal)
-    call win_execute(popup, 'highlight! link FoldColumn Normal')
 
     return popup
 endfunction

--- a/autoload/context/preview.vim
+++ b/autoload/context/preview.vim
@@ -1,7 +1,5 @@
 let s:context_buffer_name = '<context.vim>'
 
-" TODO!: use smart statusline to look like in popup
-
 function! context#preview#update_context() abort
     while 1
         let [lines, base_line] = context#preview#get_context()
@@ -68,18 +66,16 @@ function! s:show(lines, indent) abort
 
     let winid = win_getid()
 
-    let border_line = context#util#get_border_line(a:lines, a:indent, winid)
-    " TODO: don't actually add to a:lines, but use for statusline instead
-    call add(a:lines, border_line)
-
     let display_lines = []
     let hls = [] " list of lists, one per context line
     for line in a:lines
         let [text, highlights] = context#line#display(winid, line)
-        call context#util#echof('highlights', text, highlights)
+        " call context#util#echof('highlights', text, highlights)
         call add(display_lines, text)
         call add(hls, highlights)
     endfor
+
+    let border_line = context#util#get_border_line(a:lines, a:indent, winid)
 
     execute 'silent! aboveleft pedit' s:context_buffer_name
 
@@ -92,11 +88,12 @@ function! s:show(lines, indent) abort
         return [[], 0]
     endif
 
-    let statusline = s:context_buffer_name . ' ' " trailing space for padding
-    if a:indent >= 0
-        " TODO!: improve statusline
-        let statusline = g:context.ellipsis . statusline
-    endif
+    let [border_text, border_hls] = context#line#display(winid, border_line)
+    let statusline = ''
+    for hl in border_hls
+        let part = strpart(border_text, hl[1]-1, hl[2])
+        let statusline .= '%#' . hl[0] . '#' . part
+    endfor
 
     setlocal buftype=nofile
     setlocal modifiable

--- a/autoload/context/preview.vim
+++ b/autoload/context/preview.vim
@@ -91,7 +91,7 @@ function! s:show(lines, indent) abort
     let [border_text, border_hls] = context#line#display(winid, border_line)
     let statusline = ''
     for hl in border_hls
-        let part = strpart(border_text, hl[1]-1, hl[2])
+        let part = strpart(border_text, hl[1], hl[2])
         let statusline .= '%#' . hl[0] . '#' . part
     endfor
 
@@ -115,7 +115,7 @@ function! s:show(lines, indent) abort
 
     for h in range(0, len(hls)-1)
         for hl in hls[h]
-            call matchaddpos(hl[0], [[h+1, hl[1], hl[2]]], 10, -1)
+            call matchaddpos(hl[0], [[h+1, hl[1]+1, hl[2]]], 10, -1)
         endfor
     endfor
 

--- a/autoload/context/preview.vim
+++ b/autoload/context/preview.vim
@@ -1,5 +1,8 @@
 let s:context_buffer_name = '<context.vim>'
 
+" TODO!: make work for preview
+" TODO!: use smart statusline to look like in popup
+
 function! context#preview#update_context() abort
     while 1
         let [lines, base_line] = context#preview#get_context()

--- a/autoload/context/preview.vim
+++ b/autoload/context/preview.vim
@@ -27,9 +27,7 @@ function! context#preview#get_context() abort
 
     call context#util#echof('> context#preview#update_context', len(context))
 
-    let [lines, line_number] = context#util#filter(context, line_number, 0)
-
-    return [lines, line_number]
+    return context#util#filter(context, line_number, 0)
 endfunction
 
 function! context#preview#close() abort
@@ -70,6 +68,10 @@ function! s:show(lines, indent) abort
 
     let winid = win_getid()
 
+    let border_line = context#util#get_border_line(a:lines, a:indent, winid)
+    " TODO: don't actually add to a:lines, but use for statusline instead
+    call add(a:lines, border_line)
+
     let display_lines = []
     let hls = [] " list of lists, one per context line
     for line in a:lines
@@ -90,7 +92,7 @@ function! s:show(lines, indent) abort
         return [[], 0]
     endif
 
-    let statusline = '%=' . s:context_buffer_name . ' ' " trailing space for padding
+    let statusline = s:context_buffer_name . ' ' " trailing space for padding
     if a:indent >= 0
         " TODO!: improve statusline
         let statusline = g:context.ellipsis . statusline

--- a/autoload/context/settings.vim
+++ b/autoload/context/settings.vim
@@ -43,6 +43,8 @@ function! context#settings#parse() abort
     let Indent        = get(g:, 'Context_indent',        function('indent'))
     let Border_indent = get(g:, 'Context_border_indent', function('indent'))
 
+    " TODO: skip label lines
+
     " lines matching this regex will be ignored for the context
     " match whitespace only lines to show the full context
     " also by default excludes comment lines etc.

--- a/autoload/context/settings.vim
+++ b/autoload/context/settings.vim
@@ -61,6 +61,8 @@ function! context#settings#parse() abort
     " for example a `{` might be lifted to the preceeding `if` line
     let regex_join = get(g:, 'context_join_regex', '^\W*$')
 
+    " TODO: test all these highlight settings again, background color doesn't
+    " seem to work anymore on the indentation
     let default_highlight_border = 'Comment'
     let default_highlight_tag    = 'Special'
 

--- a/autoload/context/settings.vim
+++ b/autoload/context/settings.vim
@@ -61,8 +61,6 @@ function! context#settings#parse() abort
     " for example a `{` might be lifted to the preceeding `if` line
     let regex_join = get(g:, 'context_join_regex', '^\W*$')
 
-    " TODO: test all these highlight settings again, background color doesn't
-    " seem to work anymore on the indentation
     let default_highlight_border = 'Comment'
     let default_highlight_tag    = 'Special'
 

--- a/autoload/context/util.vim
+++ b/autoload/context/util.vim
@@ -237,11 +237,13 @@ function! context#util#filter(context, line_number, consider_height) abort
 
         let diff = len(inner_lines) - max_height_per_indent
 
-        let indent = inner_lines[0].indent
+        " call context#util#echof('inner_lines', inner_lines)
+
+        let indent = inner_lines[0][0].indent
         let limited = inner_lines[: max_height_per_indent/2-1]
         " TODO: use first line number of removed batch
-        let ellipsis_line = context#line#make(0, indent, repeat(' ', indent) . g:context.ellipsis)
-        call add(limited, ellipsis_line)
+        let ellipsis_lines = [context#line#make(0, indent, repeat(' ', indent) . g:context.ellipsis)]
+        call add(limited, ellipsis_lines)
         call extend(limited, inner_lines[-(max_height_per_indent-1)/2 :])
 
         call extend(lines, limited)
@@ -253,13 +255,13 @@ function! context#util#filter(context, line_number, consider_height) abort
 
     " apply total limit
     if len(lines) > max_height
-        let indent1 = lines[max_height/2].indent
-        let indent2 = lines[-(max_height-1)/2].indent
+        let indent1 = lines[max_height/2][0].indent
+        let indent2 = lines[-(max_height-1)/2][0].indent
         let ellipsis = repeat(g:context.char_ellipsis, max([indent2 - indent1, 3]))
         " TODO: use first line number of removed batch
-        let ellipsis_line = context#line#make(0, indent1, repeat(' ', indent1) . ellipsis)
+        let ellipsis_lines = [context#line#make(0, indent1, repeat(' ', indent1) . ellipsis)]
         call remove(lines, max_height/2, -(max_height+1)/2)
-        call insert(lines, ellipsis_line, max_height/2)
+        call insert(lines, ellipsis_lines, max_height/2)
     endif
 
     call map(lines, function('context#line#text'))

--- a/autoload/context/util.vim
+++ b/autoload/context/util.vim
@@ -238,7 +238,7 @@ function! context#util#filter(context, line_number, consider_height) abort
         let limited = inner_lines[: max_per_indent/2-1]
         " TODO: use first line number of removed batch
         " TODO: let c = g:context
-        let ellipsis_lines = [context#line#make_highlight(0, diff+1, g:context.char_ellipsis, indent, g:context.ellipsis, 'Comment')]
+        let ellipsis_lines = [context#line#make_highlight(0, g:context.char_ellipsis, indent, g:context.ellipsis, 'Comment')]
         call add(limited, ellipsis_lines)
         call extend(limited, inner_lines[-(max_per_indent-1)/2 :])
 
@@ -256,7 +256,7 @@ function! context#util#filter(context, line_number, consider_height) abort
         let indent2 = lines[-(max_height-1)/2][0].indent
         let ellipsis = repeat(g:context.char_ellipsis, max([indent2 - indent1, 3]))
         " TODO: use first line number of removed batch
-        let ellipsis_lines = [context#line#make_highlight(0, diff+1, g:context.char_ellipsis, indent1, ellipsis, 'Comment')]
+        let ellipsis_lines = [context#line#make_highlight(0, g:context.char_ellipsis, indent1, ellipsis, 'Comment')]
         call remove(lines, max_height/2, -(max_height+1)/2)
         call insert(lines, ellipsis_lines, max_height/2)
     endif

--- a/autoload/context/util.vim
+++ b/autoload/context/util.vim
@@ -225,19 +225,19 @@ function! context#util#filter(context, line_number, consider_height) abort
         endfor
 
         " apply max per indent
-        if len(inner_lines) <= max_per_indent
+        let diff = len(inner_lines) - max_per_indent
+        if diff <= 0
             call extend(lines, inner_lines)
             continue
         endif
 
-        let diff = len(inner_lines) - max_per_indent
 
         " call context#util#echof('inner_lines', inner_lines)
 
         let indent = inner_lines[0][0].indent
         let limited = inner_lines[: max_per_indent/2-1]
         " TODO: use first line number of removed batch
-        let ellipsis_lines = [context#line#make_highlight(0, indent, g:context.ellipsis, 'Comment')]
+        let ellipsis_lines = [context#line#make_highlight(0, diff, indent, g:context.ellipsis, 'Comment')]
         call add(limited, ellipsis_lines)
         call extend(limited, inner_lines[-(max_per_indent-1)/2 :])
 
@@ -249,12 +249,13 @@ function! context#util#filter(context, line_number, consider_height) abort
     endif
 
     " apply total limit
-    if len(lines) > max_height
+    let diff = len(lines) - max_height
+    if diff > 0
         let indent1 = lines[max_height/2][0].indent
         let indent2 = lines[-(max_height-1)/2][0].indent
         let ellipsis = repeat(g:context.char_ellipsis, max([indent2 - indent1, 3]))
         " TODO: use first line number of removed batch
-        let ellipsis_lines = [context#line#make_highlight(0, indent1, ellipsis, 'Comment')]
+        let ellipsis_lines = [context#line#make_highlight(0, diff, indent1, ellipsis, 'Comment')]
         call remove(lines, max_height/2, -(max_height+1)/2)
         call insert(lines, ellipsis_lines, max_height/2)
     endif

--- a/autoload/context/util.vim
+++ b/autoload/context/util.vim
@@ -166,12 +166,6 @@ function! context#util#update_window_state(winid) abort
     endif
 endfunction
 
-" TODO!: there's a bug:
-" normal.c, line 2788
-" ztj
-" shows `... {` even though the { is visible below the border line
-" on master too
-
 " this is a pretty weird function
 " it has been extracted to reduce duplication between popup and preview code
 " what it does: it goes through all lines of the given full context and
@@ -217,7 +211,7 @@ function! context#util#filter(context, line_number, consider_height) abort
             endif
 
             for i in range(1, len(join_batch)-1)
-                if join_batch[i].number > w:context.top_line + height
+                if join_batch[i].number >= w:context.top_line + height
                     let line_number = join_batch[i].number
                     let done = 1
                     call remove(join_batch, i, -1)

--- a/autoload/context/util.vim
+++ b/autoload/context/util.vim
@@ -270,7 +270,6 @@ function! context#util#filter(context, line_number, consider_height) abort
 
         let indent = inner_lines[0][0].indent
         let limited = inner_lines[: max_per_indent/2-1]
-        " TODO: use first line number of removed batch
         " TODO: let c = g:context
         let ellipsis_lines = [context#line#make_highlight(0, g:context.char_ellipsis, indent, g:context.ellipsis, 'Comment')]
         call add(limited, ellipsis_lines)
@@ -289,7 +288,6 @@ function! context#util#filter(context, line_number, consider_height) abort
         let indent1 = lines[max_height/2][0].indent
         let indent2 = lines[-(max_height-1)/2][0].indent
         let ellipsis = repeat(g:context.char_ellipsis, max([indent2 - indent1, 3]))
-        " TODO: use first line number of removed batch
         let ellipsis_lines = [context#line#make_highlight(0, g:context.char_ellipsis, indent1, ellipsis, 'Comment')]
         call remove(lines, max_height/2, -(max_height+1)/2)
         call insert(lines, ellipsis_lines, max_height/2)

--- a/autoload/context/util.vim
+++ b/autoload/context/util.vim
@@ -237,7 +237,7 @@ function! context#util#filter(context, line_number, consider_height) abort
         let indent = inner_lines[0][0].indent
         let limited = inner_lines[: max_per_indent/2-1]
         " TODO: use first line number of removed batch
-        let ellipsis_lines = [context#line#make(0, indent, repeat(' ', indent) . g:context.ellipsis)]
+        let ellipsis_lines = [context#line#make(0, indent, g:context.ellipsis)]
         call add(limited, ellipsis_lines)
         call extend(limited, inner_lines[-(max_per_indent-1)/2 :])
 
@@ -254,7 +254,7 @@ function! context#util#filter(context, line_number, consider_height) abort
         let indent2 = lines[-(max_height-1)/2][0].indent
         let ellipsis = repeat(g:context.char_ellipsis, max([indent2 - indent1, 3]))
         " TODO: use first line number of removed batch
-        let ellipsis_lines = [context#line#make(0, indent1, repeat(' ', indent1) . ellipsis)]
+        let ellipsis_lines = [context#line#make(0, indent1, ellipsis)]
         call remove(lines, max_height/2, -(max_height+1)/2)
         call insert(lines, ellipsis_lines, max_height/2)
     endif

--- a/autoload/context/util.vim
+++ b/autoload/context/util.vim
@@ -90,6 +90,34 @@ function! context#util#update_state() abort
     let w:context.top_line = top_line
     let w:context.cursor_line = cursor_line
 
+    if &number
+        " depends on total number of lines
+        let number_width = max([&numberwidth, float2nr(ceil(log10(line('$') + 1))) + 1])
+    elseif &relativenumber
+        " depends on number of visible lines
+        let number_width = max([&numberwidth, float2nr(ceil(log10(&lines - 1))) + 1])
+    else
+        let number_width = 0
+    endif
+    if w:context.number_width != number_width
+        call context#util#echof('number width changed', w:context.number_width, number_width)
+        let w:context.number_width = number_width
+        let w:context.needs_update = 1
+    endif
+
+    let old = [&virtualedit, &conceallevel]
+    let [&virtualedit, &conceallevel] = ['all', 0]
+    let sign_width = wincol() - virtcol('.') - number_width
+    let [&virtualedit, &conceallevel] = old
+    " NOTE: sign_width can be negative if the cursor is on the wrapped part of
+    " a wrapped line. in that case ignore the value
+    if sign_width >= 0 && w:context.sign_width != sign_width
+        call context#util#echof('sign width changed', w:context.sign_width, sign_width)
+        let w:context.sign_width = sign_width
+        let w:context.needs_update = 1
+    endif
+
+    " TODO: remove padding, use sign_width and number_width exclusively instead
     " padding can only be checked for the current window
     let padding = wincol() - virtcol('.')
     " NOTE: if 'list' is set and the cursor is on a Tab character the cursor

--- a/autoload/context/util.vim
+++ b/autoload/context/util.vim
@@ -253,6 +253,11 @@ function! context#util#filter(context, line_number, consider_height) abort
         return [[], 0]
     endif
 
+    " TODO!: there's another bug: in total.c
+    " starting around line 100, wher scrolling down, lines which should go
+    " into the context disappear behind the border line, but don't show up in
+    " context
+
     " apply total limit
     if len(lines) > max_height
         let indent1 = lines[max_height/2][0].indent

--- a/autoload/context/util.vim
+++ b/autoload/context/util.vim
@@ -259,7 +259,6 @@ function! context#util#filter(context, line_number, consider_height) abort
         call insert(lines, ellipsis_lines, max_height/2)
     endif
 
-    call map(lines, function('context#line#text'))
     return [lines, line_number]
 endfunction
 

--- a/autoload/context/util.vim
+++ b/autoload/context/util.vim
@@ -178,9 +178,10 @@ endfunction
 " to be displayed together with the line_number which should be used for the
 " indentation of the border line/status line
 function! context#util#filter(context, line_number, consider_height) abort
-    let line_number = a:line_number
-    let max_height = g:context.max_height
-    let max_height_per_indent = g:context.max_per_indent
+    let line_number    = a:line_number
+    let show_border    = g:context.show_border
+    let max_height     = g:context.max_height
+    let max_per_indent = g:context.max_per_indent
 
     let height = 0
     let done = 0
@@ -203,9 +204,9 @@ function! context#util#filter(context, line_number, consider_height) abort
             endif
 
             if a:consider_height
-                if height == 0 && g:context.show_border
+                if height == 0 && show_border
                     let height += 2 " adding border line
-                elseif height < max_height && len(inner_lines) < max_height_per_indent
+                elseif height < max_height + show_border && len(inner_lines) < max_per_indent
                     let height += 1
                 endif
             endif
@@ -224,21 +225,21 @@ function! context#util#filter(context, line_number, consider_height) abort
         endfor
 
         " apply max per indent
-        if len(inner_lines) <= max_height_per_indent
+        if len(inner_lines) <= max_per_indent
             call extend(lines, inner_lines)
             continue
         endif
 
-        let diff = len(inner_lines) - max_height_per_indent
+        let diff = len(inner_lines) - max_per_indent
 
         " call context#util#echof('inner_lines', inner_lines)
 
         let indent = inner_lines[0][0].indent
-        let limited = inner_lines[: max_height_per_indent/2-1]
+        let limited = inner_lines[: max_per_indent/2-1]
         " TODO: use first line number of removed batch
         let ellipsis_lines = [context#line#make(0, indent, repeat(' ', indent) . g:context.ellipsis)]
         call add(limited, ellipsis_lines)
-        call extend(limited, inner_lines[-(max_height_per_indent-1)/2 :])
+        call extend(limited, inner_lines[-(max_per_indent-1)/2 :])
 
         call extend(lines, limited)
     endfor
@@ -246,11 +247,6 @@ function! context#util#filter(context, line_number, consider_height) abort
     if len(lines) == 0
         return [[], 0]
     endif
-
-    " TODO!: there's another bug: in total.c
-    " starting around line 100, wher scrolling down, lines which should go
-    " into the context disappear behind the border line, but don't show up in
-    " context
 
     " apply total limit
     if len(lines) > max_height

--- a/autoload/context/util.vim
+++ b/autoload/context/util.vim
@@ -237,7 +237,8 @@ function! context#util#filter(context, line_number, consider_height) abort
         let indent = inner_lines[0][0].indent
         let limited = inner_lines[: max_per_indent/2-1]
         " TODO: use first line number of removed batch
-        let ellipsis_lines = [context#line#make_highlight(0, diff+1, indent, g:context.ellipsis, 'Comment')]
+        " TODO: let c = g:context
+        let ellipsis_lines = [context#line#make_highlight(0, diff+1, g:context.char_ellipsis, indent, g:context.ellipsis, 'Comment')]
         call add(limited, ellipsis_lines)
         call extend(limited, inner_lines[-(max_per_indent-1)/2 :])
 
@@ -255,7 +256,7 @@ function! context#util#filter(context, line_number, consider_height) abort
         let indent2 = lines[-(max_height-1)/2][0].indent
         let ellipsis = repeat(g:context.char_ellipsis, max([indent2 - indent1, 3]))
         " TODO: use first line number of removed batch
-        let ellipsis_lines = [context#line#make_highlight(0, diff+1, indent1, ellipsis, 'Comment')]
+        let ellipsis_lines = [context#line#make_highlight(0, diff+1, g:context.char_ellipsis, indent1, ellipsis, 'Comment')]
         call remove(lines, max_height/2, -(max_height+1)/2)
         call insert(lines, ellipsis_lines, max_height/2)
     endif

--- a/autoload/context/util.vim
+++ b/autoload/context/util.vim
@@ -237,8 +237,7 @@ function! context#util#filter(context, line_number, consider_height) abort
         let indent = inner_lines[0][0].indent
         let limited = inner_lines[: max_per_indent/2-1]
         " TODO: use first line number of removed batch
-        " TODO!: probably better use diff+1, test again
-        let ellipsis_lines = [context#line#make_highlight(0, diff, indent, g:context.ellipsis, 'Comment')]
+        let ellipsis_lines = [context#line#make_highlight(0, diff+1, indent, g:context.ellipsis, 'Comment')]
         call add(limited, ellipsis_lines)
         call extend(limited, inner_lines[-(max_per_indent-1)/2 :])
 
@@ -256,8 +255,7 @@ function! context#util#filter(context, line_number, consider_height) abort
         let indent2 = lines[-(max_height-1)/2][0].indent
         let ellipsis = repeat(g:context.char_ellipsis, max([indent2 - indent1, 3]))
         " TODO: use first line number of removed batch
-        " TODO!: use diff+1 here too? test again
-        let ellipsis_lines = [context#line#make_highlight(0, diff, indent1, ellipsis, 'Comment')]
+        let ellipsis_lines = [context#line#make_highlight(0, diff+1, indent1, ellipsis, 'Comment')]
         call remove(lines, max_height/2, -(max_height+1)/2)
         call insert(lines, ellipsis_lines, max_height/2)
     endif

--- a/autoload/context/util.vim
+++ b/autoload/context/util.vim
@@ -102,7 +102,7 @@ function! context#util#update_state() abort
         let number_width = 0
     endif
     if w:context.number_width != number_width
-        call context#util#echof('number width changed', w:context.number_width, number_width)
+        " call context#util#echof('number width changed', w:context.number_width, number_width)
         let w:context.number_width = number_width
         let w:context.needs_update = 1
     endif
@@ -114,7 +114,7 @@ function! context#util#update_state() abort
     " NOTE: sign_width can be negative if the cursor is on the wrapped part of
     " a wrapped line. in that case ignore the value
     if sign_width >= 0 && w:context.sign_width != sign_width
-        call context#util#echof('sign width changed', w:context.sign_width, sign_width)
+        " call context#util#echof('sign width changed', w:context.sign_width, sign_width)
         let w:context.sign_width = sign_width
         let w:context.needs_update = 1
     endif
@@ -302,22 +302,6 @@ function! context#util#limit_join_parts(lines) abort
     endwhile
 
     return a:lines
-endfunction
-
-" TODO: move to popup.vim? used anywhere else?
-function! context#util#show_cursor() abort
-    " compare height of context to cursor line on screen
-    let n = len(w:context.lines) + g:context.show_border - (w:context.cursor_line - w:context.top_line)
-    if n <= 0
-        " if cursor is low enough, nothing to do
-        return
-    end
-
-    " otherwise we have to either move or scroll the cursor accordingly
-    " call context#util#echof('show_cursor', w:context.fix_strategy, n)
-    let key = (w:context.fix_strategy == 'move') ? 'j' : "\<C-Y>"
-    execute 'normal! ' . n . key
-    call context#util#update_line_state()
 endfunction
 
 let s:log_indent = 0

--- a/autoload/context/util.vim
+++ b/autoload/context/util.vim
@@ -233,6 +233,7 @@ function! context#util#filter(context, line_number, consider_height) abort
 
         let indent = inner_lines[0].indent
         let limited = inner_lines[: max_height_per_indent/2-1]
+        " TODO: use first line number of removed batch
         let ellipsis_line = context#line#make(0, indent, repeat(' ', indent) . g:context.ellipsis)
         call add(limited, ellipsis_line)
         call extend(limited, inner_lines[-(max_height_per_indent-1)/2 :])
@@ -249,6 +250,7 @@ function! context#util#filter(context, line_number, consider_height) abort
         let indent1 = lines[max_height/2].indent
         let indent2 = lines[-(max_height-1)/2].indent
         let ellipsis = repeat(g:context.char_ellipsis, max([indent2 - indent1, 3]))
+        " TODO: use first line number of removed batch
         let ellipsis_line = context#line#make(0, indent1, repeat(' ', indent1) . ellipsis)
         call remove(lines, max_height/2, -(max_height+1)/2)
         call insert(lines, ellipsis_line, max_height/2)

--- a/autoload/context/util.vim
+++ b/autoload/context/util.vim
@@ -237,7 +237,7 @@ function! context#util#filter(context, line_number, consider_height) abort
         let indent = inner_lines[0][0].indent
         let limited = inner_lines[: max_per_indent/2-1]
         " TODO: use first line number of removed batch
-        let ellipsis_lines = [context#line#make(0, indent, g:context.ellipsis)]
+        let ellipsis_lines = [context#line#make_highlight(0, indent, g:context.ellipsis, 'Comment')]
         call add(limited, ellipsis_lines)
         call extend(limited, inner_lines[-(max_per_indent-1)/2 :])
 
@@ -254,7 +254,7 @@ function! context#util#filter(context, line_number, consider_height) abort
         let indent2 = lines[-(max_height-1)/2][0].indent
         let ellipsis = repeat(g:context.char_ellipsis, max([indent2 - indent1, 3]))
         " TODO: use first line number of removed batch
-        let ellipsis_lines = [context#line#make(0, indent1, ellipsis)]
+        let ellipsis_lines = [context#line#make_highlight(0, indent1, ellipsis, 'Comment')]
         call remove(lines, max_height/2, -(max_height+1)/2)
         call insert(lines, ellipsis_lines, max_height/2)
     endif

--- a/autoload/context/util.vim
+++ b/autoload/context/util.vim
@@ -17,6 +17,10 @@ function! context#util#map_H() abort
     if mode(1) == 'niI' " i^o
         return 'H'
     endif
+    if g:context.presenter == 'preview'
+        " nothing needed for preview
+        return 'H'
+    endif
     " TODO: handle scrolloff
     let n = len(w:context.lines) + g:context.show_border + v:count1
     return "\<Esc>". n . 'H'

--- a/autoload/context/util.vim
+++ b/autoload/context/util.vim
@@ -237,6 +237,7 @@ function! context#util#filter(context, line_number, consider_height) abort
         let indent = inner_lines[0][0].indent
         let limited = inner_lines[: max_per_indent/2-1]
         " TODO: use first line number of removed batch
+        " TODO!: probably better use diff+1, test again
         let ellipsis_lines = [context#line#make_highlight(0, diff, indent, g:context.ellipsis, 'Comment')]
         call add(limited, ellipsis_lines)
         call extend(limited, inner_lines[-(max_per_indent-1)/2 :])
@@ -255,6 +256,7 @@ function! context#util#filter(context, line_number, consider_height) abort
         let indent2 = lines[-(max_height-1)/2][0].indent
         let ellipsis = repeat(g:context.char_ellipsis, max([indent2 - indent1, 3]))
         " TODO: use first line number of removed batch
+        " TODO!: use diff+1 here too? test again
         let ellipsis_lines = [context#line#make_highlight(0, diff, indent1, ellipsis, 'Comment')]
         call remove(lines, max_height/2, -(max_height+1)/2)
         call insert(lines, ellipsis_lines, max_height/2)

--- a/autoload/context/util.vim
+++ b/autoload/context/util.vim
@@ -166,6 +166,12 @@ function! context#util#update_window_state(winid) abort
     endif
 endfunction
 
+" TODO!: there's a bug:
+" normal.c, line 2788
+" ztj
+" shows `... {` even though the { is visible below the border line
+" on master too
+
 " this is a pretty weird function
 " it has been extracted to reduce duplication between popup and preview code
 " what it does: it goes through all lines of the given full context and

--- a/autoload/context/util.vim
+++ b/autoload/context/util.vim
@@ -225,8 +225,8 @@ function! context#util#filter(context, line_number, consider_height) abort
                 endif
             endfor
 
-            let line = context#line#join(join_batch)
-            call add(inner_lines, line)
+            let joined_lines = context#line#join(join_batch)
+            call add(inner_lines, joined_lines)
         endfor
 
         " apply max per indent

--- a/autoload/context/util.vim
+++ b/autoload/context/util.vim
@@ -16,7 +16,7 @@ function! context#util#map_H() abort
         return 'H'
     endif
     " TODO: handle scrolloff
-    let n = len(w:context.lines) + v:count1
+    let n = len(w:context.lines) + g:context.show_border + v:count1
     return "\<Esc>". n . 'H'
 endfunction
 
@@ -264,7 +264,7 @@ endfunction
 
 function! context#util#show_cursor() abort
     " compare height of context to cursor line on screen
-    let n = len(w:context.lines) - (w:context.cursor_line - w:context.top_line)
+    let n = len(w:context.lines) + g:context.show_border - (w:context.cursor_line - w:context.top_line)
     if n <= 0
         " if cursor is low enough, nothing to do
         return

--- a/plugin/context.vim
+++ b/plugin/context.vim
@@ -48,7 +48,7 @@ if g:context.add_autocmds
         autocmd VimResized   * call context#update('VimResized')
         autocmd CursorHold   * call context#update('CursorHold')
         autocmd User GitGutter call context#update('GitGutter')
-        " TODO: there's a bug here, if number is set and you toggle
+        " TODO!: there's a bug here, if number is set and you toggle
         " relativenumber, then the context doesn't get updated
         autocmd OptionSet number,relativenumber,numberwidth,signcolumn,tabstop
                     \          call context#update('OptionSet')

--- a/plugin/context.vim
+++ b/plugin/context.vim
@@ -37,6 +37,7 @@ endif
 
 
 " autocommands
+" TODO: update docs
 if g:context.add_autocmds
     augroup context.vim
         autocmd!
@@ -47,7 +48,10 @@ if g:context.add_autocmds
         autocmd VimResized   * call context#update('VimResized')
         autocmd CursorHold   * call context#update('CursorHold')
         autocmd User GitGutter call context#update('GitGutter')
-        " TODO: add autocommands for options changed (number, relativenumber, list, etc)
+        " TODO: there's a bug here, if number is set and you toggle
+        " relativenumber, then the context doesn't get updated
+        autocmd OptionSet number,relativenumber,numberwidth,signcolumn,tabstop
+                    \          call context#update('OptionSet')
     augroup END
 endif
 

--- a/plugin/context.vim
+++ b/plugin/context.vim
@@ -37,7 +37,6 @@ endif
 
 
 " autocommands
-" TODO: update docs
 if g:context.add_autocmds
     augroup context.vim
         autocmd!

--- a/plugin/context.vim
+++ b/plugin/context.vim
@@ -48,8 +48,6 @@ if g:context.add_autocmds
         autocmd VimResized   * call context#update('VimResized')
         autocmd CursorHold   * call context#update('CursorHold')
         autocmd User GitGutter call context#update('GitGutter')
-        " TODO!: there's a bug here, if number is set and you toggle
-        " relativenumber, then the context doesn't get updated
         autocmd OptionSet number,relativenumber,numberwidth,signcolumn,tabstop
                     \          call context#update('OptionSet')
     augroup END

--- a/plugin/context.vim
+++ b/plugin/context.vim
@@ -47,7 +47,7 @@ if g:context.add_autocmds
         autocmd VimResized   * call context#update('VimResized')
         autocmd CursorHold   * call context#update('CursorHold')
         autocmd User GitGutter call context#update('GitGutter')
-        autocmd OptionSet number,relativenumber,numberwidth,signcolumn,tabstop
+        autocmd OptionSet number,relativenumber,numberwidth,signcolumn,tabstop,list
                     \          call context#update('OptionSet')
     augroup END
 endif

--- a/plugin/context.vim
+++ b/plugin/context.vim
@@ -47,6 +47,7 @@ if g:context.add_autocmds
         autocmd VimResized   * call context#update('VimResized')
         autocmd CursorHold   * call context#update('CursorHold')
         autocmd User GitGutter call context#update('GitGutter')
+        " TODO: add autocommands for options changed (number, relativenumber, list, etc)
     augroup END
 endif
 

--- a/test/join.go
+++ b/test/join.go
@@ -1,14 +1,15 @@
 package main
 
-import ""
 
-func f(t *testing.T) {
+func f(t *testing.T)
+{
 	for i, tc := range []struct {
 		b string
 		t string
 		f bool
 		c bool
-	}{
+	}
+	{
 
 		{
 			b: otherToken,


### PR DESCRIPTION
Close #40 

This PR changes the way the highlighting works. Before we used the `'syntax'` option which had some limitations. Now we switched to manually highlighting everything based on some work from @zsugabubus in https://github.com/zsugabubus/vim-paperplane. Huge thanks btw! ❤️

This allows us to show line numbers and other minor stylistic improvements. Here's a new screenshot:

![context-example](https://user-images.githubusercontent.com/474504/91094989-e4027480-e65b-11ea-9917-d060fb5b9f49.png)
