### PR TITLE
40 Fix highlighting in Vim

### DIFF
--- a/autoload/context/line.vim
+++ b/autoload/context/line.vim
@@ -111,7 +111,7 @@ function! context#line#display(winid, join_parts) abort
         let width = len(part)
         " NOTE: this highlight wouldn't be necessary for popup, but is added
         " to make it easier to assemble the statusline for preview
-        call add(highlights, ['Whitespace', len(text), width])
+        call add(highlights, ['NonText', len(text), width])
         let text .= part
     endif
 

--- a/autoload/context/preview.vim
+++ b/autoload/context/preview.vim
@@ -65,6 +65,7 @@ function! s:show(lines, indent) abort
     endif
 
     let winid = win_getid()
+    let list  = &list
 
     let display_lines = []
     let hls = [] " list of lists, one per context line
@@ -95,6 +96,7 @@ function! s:show(lines, indent) abort
         let statusline .= '%#' . hl[0] . '#' . part
     endfor
 
+    let &list = list
     setlocal buftype=nofile
     setlocal modifiable
     setlocal nobuflisted


### PR DESCRIPTION
Turns out I was using a highlight group `Whitespace` which only exists in Neovim, not Vim. This PR switches to `NonText` which exists in both. Also set `'list'` option properly when using the preview window.

This was introduced in #81 (for #40) and reported in https://github.com/wellle/context.vim/issues/69#issuecomment-679922541.