### PR TITLE
81 Separate concepts of level and indent

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,12 +153,13 @@ let g:context_join_regex = '^\W*$'
 ```
 If we extended the context on some indent, we will join a line of this indent into the one above if the lower one matches this regular expression. So back in the C-style case where our context contains an `if (condition)` line and a `{` line below, they will be merged to `if (condition) {`. And that is because the `{` line matched this regular expression. By default we join everything which has no word characters.
 
+TODO: update docs
 ```vim
-let g:Context_indent = function('indent')
+let g:Context_indent = { line -> [indent(line), indent(line)] }
 ```
 By default we create the context based on the indentation of the context lines. As we scan through the buffer lines we add lines to the context if they have less indent than the last context line. To get the indentation of a given buffer line we use the `indent()` function. You can use this setting to use your own function instead. That way you can customize what goes into your context.
 
-The function takes a line number and is supposed to return a number which you could consider a virtual indent. Smaller indent number means bigger scope, just like indentation. Make sure to return -1 if an invalid line number gets passed in, like `indent()` does.
+The function takes a line number and is supposed to return two numbers. The first one is the level. Smaller level means bigger scope, just like indentation. Make sure to return -1 if an invalid line number gets passed in, like `indent()` does. The second return value is the indentation used for display. You probably want to keep using `indent()` for this one. 
 
 Here's an example that considers Markdown headers for the context: [#45][indent-example] (Note that you need to change `g:context_skip_regex` too to make this work)
 

--- a/autoload/context.vim
+++ b/autoload/context.vim
@@ -67,6 +67,7 @@ function! context#update(...) abort
                     \ 'pos_x':              0,
                     \ 'size_h':             0,
                     \ 'size_w':             0,
+                    \ 'level':              0,
                     \ 'indent':             0,
                     \ 'needs_layout':       0,
                     \ 'needs_update':       0,

--- a/autoload/context/line.vim
+++ b/autoload/context/line.vim
@@ -1,12 +1,13 @@
-function! context#line#make(number, indent, text) abort
-    return context#line#make_highlight(a:number, '', a:indent, a:text, '')
+function! context#line#make(number, level, indent, text) abort
+    return context#line#make_highlight(a:number, '', a:level, a:indent, a:text, '')
 endfunction
 
-function! context#line#make_trimmed(number, indent, text) abort
+function! context#line#make_trimmed(number, level, indent, text) abort
     let trimmed_text = s:trim(a:text)
     return {
                 \ 'number':         a:number,
                 \ 'number_char':    '',
+                \ 'level':          a:level,
                 \ 'indent':         a:indent,
                 \ 'indent_chars':   len(a:text) - len(trimmed_text),
                 \ 'text':           trimmed_text,
@@ -14,10 +15,11 @@ function! context#line#make_trimmed(number, indent, text) abort
                 \ }
 endfunction
 
-function! context#line#make_highlight(number, number_char, indent, text, highlight) abort
+function! context#line#make_highlight(number, number_char, level, indent, text, highlight) abort
     return {
                 \ 'number':         a:number,
                 \ 'number_char':    a:number_char,
+                \ 'level':          a:level,
                 \ 'indent':         a:indent,
                 \ 'indent_chars':   a:indent,
                 \ 'text':           a:text,
@@ -29,13 +31,13 @@ function! s:trim(string) abort
     return substitute(a:string, '^\s*', '', '')
 endfunction
 
-let s:nil_line = context#line#make(0, 0, '')
+let s:nil_line = context#line#make(0, 0, 0, '')
 
 " find line downwards (from given line) which isn't empty
 function! context#line#get_base_line(line) abort
     let current_line = a:line
     while 1
-        let indent = g:context.Indent(current_line)
+        let [level, indent] = g:context.Indent(current_line)
         if indent < 0 " invalid line
             return s:nil_line
         endif
@@ -46,7 +48,7 @@ function! context#line#get_base_line(line) abort
             continue
         endif
 
-        return context#line#make(current_line, indent, text)
+        return context#line#make(current_line, level, indent, text)
     endwhile
 endfunction
 

--- a/autoload/context/popup.vim
+++ b/autoload/context/popup.vim
@@ -5,7 +5,7 @@ function! context#popup#update_context() abort
     " NOTE: we remember context lines and baseline indent per window so we can
     " redraw them in #layout when the window layout changes
     let w:context.lines  = lines
-    let w:context.indent = g:context.Border_indent(base_line)
+    let [w:context.level, w:context.indent] = g:context.Border_indent(base_line)
 
     call s:show_cursor()
     call s:show()
@@ -27,7 +27,7 @@ function! context#popup#get_context() abort
     while 1
         let line_number += 1
 
-        let indent = g:context.Indent(line_number) " -1 for invalid lines
+        let [level, indent] = g:context.Indent(line_number) " -1 for invalid lines
         if indent < 0
             call context#util#echof('negative indent', line_number)
             return [[], 0]
@@ -40,7 +40,7 @@ function! context#popup#get_context() abort
             continue
         endif
 
-        let base_line = context#line#make(line_number, indent, text)
+        let base_line = context#line#make(line_number, level, indent, text)
         let [context, line_count] = context#context#get(base_line)
         call context#util#echof('context#get', line_number, line_count)
 
@@ -122,7 +122,7 @@ function! context#popup#redraw(winid) abort
     endfor
 
     if g:context.show_border
-        let border_line = context#util#get_border_line(c.lines, w:context.indent, a:winid)
+        let border_line = context#util#get_border_line(c.lines, w:context.level, w:context.indent, a:winid)
         let [text, highlights] = context#line#display(a:winid, border_line)
         call add(display_lines, text)
         call add(hls, highlights)

--- a/autoload/context/preview.vim
+++ b/autoload/context/preview.vim
@@ -3,10 +3,10 @@ let s:context_buffer_name = '<context.vim>'
 function! context#preview#update_context() abort
     while 1
         let [lines, base_line] = context#preview#get_context()
-        let indent = g:context.Indent(base_line)
+        let [level, indent] = g:context.Indent(base_line)
 
         call context#preview#close()
-        call s:show(lines, indent)
+        call s:show(lines, level, indent)
 
         let w:context.needs_update = 0
         call context#util#update_state() " NOTE: this might set w:context.needs_update
@@ -57,7 +57,7 @@ function! context#preview#close() abort
     let layout = winrestcmd() | set equalalways | noautocmd execute layout
 endfunction
 
-function! s:show(lines, indent) abort
+function! s:show(lines, level, indent) abort
     if len(a:lines) == 0
         " nothing to do
         call context#util#echof('  none')
@@ -76,7 +76,7 @@ function! s:show(lines, indent) abort
         call add(hls, highlights)
     endfor
 
-    let border_line = context#util#get_border_line(a:lines, a:indent, winid)
+    let border_line = context#util#get_border_line(a:lines, a:level, a:indent, winid)
 
     execute 'silent! aboveleft pedit' s:context_buffer_name
 

--- a/autoload/context/settings.vim
+++ b/autoload/context/settings.vim
@@ -27,8 +27,10 @@ function! context#settings#parse() abort
     " how many lines to use at most for the context
     let max_height = get(g:, 'context_max_height', 21)
 
-    " how many lines are allowed per indent
-    let max_per_indent = get(g:, 'context_max_per_indent', 5)
+    " how many lines are allowed per level
+    " NOTE: the setting is called per_indent for legacy reasons
+    " TODO: might want to rename the setting and keep the legacy fallback
+    let max_per_level = get(g:, 'context_max_per_indent', 5)
 
     " how many lines can be joined in one line (if they match
     " regex_join) before the ones in the middle get hidden
@@ -40,8 +42,8 @@ function! context#settings#parse() abort
     let char_border = get(g:, 'context_border_char', '▬')
 
     " indent function used to create the context
-    let Indent        = get(g:, 'Context_indent',        function('indent'))
-    let Border_indent = get(g:, 'Context_border_indent', function('indent'))
+    let Indent        = get(g:, 'Context_indent',        function('s:indent'))
+    let Border_indent = get(g:, 'Context_border_indent', function('s:indent'))
 
     " TODO: skip label lines
 
@@ -97,7 +99,7 @@ function! context#settings#parse() abort
                 \ 'add_mappings':        add_mappings,
                 \ 'add_autocmds':        add_autocmds,
                 \ 'max_height':          max_height,
-                \ 'max_per_indent':      max_per_indent,
+                \ 'max_per_level':       max_per_level,
                 \ 'max_join_parts':      max_join_parts,
                 \ 'char_ellipsis':       char_ellipsis,
                 \ 'char_border':         char_border,
@@ -118,4 +120,9 @@ function! context#settings#parse() abort
                 \ 'popups':              {},
                 \ 'windows':             {},
                 \ }
+endfunction
+
+function! s:indent(line) abort
+    let indent = indent(a:line)
+    return [indent, indent]
 endfunction


### PR DESCRIPTION
>Use new level to group context lines in order to limit lines per level.
>Keep indent to display context lines.

>Update custom indent function interface to return both of these values instead of just the indent. That way custom indent functions can handle special levels while still using the default indent() for displaying purposes.

Another issue introduced in #81, reported in https://github.com/wellle/context.vim/issues/69#issuecomment-681835775.

Close #69 again.

⚠️ This is a breaking change as it changes the interface of the custom indent functions. See the changes in the README. I just updated the linked example, see https://github.com/wellle/context.vim/pull/45#issuecomment-582654810.

So if you use custom indent functions you will have to update them to return both the logical level and the physical indent (to be used for displaying purposes)