### PR TITLE
85 Echo a warning about deprecated custom indent functions

### DIFF
--- a/autoload/context/settings.vim
+++ b/autoload/context/settings.vim
@@ -42,8 +42,19 @@ function! context#settings#parse() abort
     let char_border = get(g:, 'context_border_char', '▬')
 
     " indent function used to create the context
-    let Indent        = get(g:, 'Context_indent',        function('s:indent'))
-    let Border_indent = get(g:, 'Context_border_indent', function('s:indent'))
+    let Default_indent = function('s:indent')
+    let Indent         = get(g:, 'Context_indent',        Default_indent)
+    let Border_indent  = get(g:, 'Context_border_indent', Default_indent)
+
+    if type(Indent(0)) == type(0)
+        echom 'context.vim warning:'
+        echom '  The interfaces of custom indent functions have changed. They expect two'
+        echom '  return values now. Your implementation is ignored until you update it'
+        echom '  accordingly. Sorry for the inconvenience!'
+        echom '  See https://github.com/wellle/context.vim/pull/85'
+        let Indent        = Default_indent
+        let Border_indent = Default_indent
+    endif
 
     " TODO: skip label lines
 


### PR DESCRIPTION
>And fall back to default behavior in that case to avoid errors.

Follow up to #85.

This is indented to avoid users running into errors when upgrading context.vim. Instead of running into the errors we check if old style custom indent functions are being used and output a warning in that case and ignore the implementations and fall back to default behavior. That should give users a better explanation of what's going on and make it easier to make the required changes.