### PR TITLE
81 Change default border character

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ let g:context_ellipsis_char = '·'
 By default we use this character (digraph `.M`) in our ellipsis (`···`). Change this variable if this character doesn't work for you or if you don't like it.
 
 ```vim
-g:context_border_char = '▬'
+g:context_border_char = '━'
 ```
 
 If your Vim/Neovim version supports popup/floating windows we draw a line to separate the context from your buffer context. This character is used to do that.

--- a/autoload/context/line.vim
+++ b/autoload/context/line.vim
@@ -69,7 +69,7 @@ function! context#line#display(winid, join_parts) abort
     " sign column
     let width = c.sign_width
     if width > 0
-        let part = repeat(' ', width)
+        let part = repeat(' ', width)
         let width = len(part)
         call add(highlights, ['SignColumn', len(text), width])
         let text .= part
@@ -79,9 +79,7 @@ function! context#line#display(winid, join_parts) abort
     let width = c.number_width
     if width > 0
         if part0.number_char != ''
-            " NOTE: we use a non breaking space here because number_char can
-            " be border_char
-            let part = repeat(part0.number_char, width-1) . ' '
+            let part = repeat(part0.number_char, width-1) . ' '
         else
             if &relativenumber
                 let n = c.cursor_line - part0.number
@@ -97,7 +95,7 @@ function! context#line#display(winid, join_parts) abort
                 let n = 0
             endif
             " let part = printf('%*d ', width - 1, n)
-            let part = repeat(' ', width-len(n)-1) . n . ' '
+            let part = repeat(' ', width-len(n)-1) . n . ' '
         endif
 
         let width = len(part)

--- a/autoload/context/settings.vim
+++ b/autoload/context/settings.vim
@@ -39,7 +39,17 @@ function! context#settings#parse() abort
     " which character to use for the ellipsis "..."
     let char_ellipsis = get(g:, 'context_ellipsis_char', '·')
 
-    let char_border = get(g:, 'context_border_char', '▬')
+    " NOTE: we switched away from the earlier default value '▬' because there
+    " still is a display issue in the Kitty terminal:
+    " ▬▬▬▬ <context.vim>
+    " if you look at that line in terminal you will notice that the last
+    " instance of the character is displayed differently than the others.
+    " we used to work around this by using a non breaking space after the last
+    " character:
+    " ▬▬▬▬ <context.vim>
+    " but this led to other issues later on (see #81) so we switched to this
+    " new default border char which doesn't have such issues
+    let char_border = get(g:, 'context_border_char', '━')
 
     " indent function used to create the context
     let Default_indent = function('s:indent')

--- a/autoload/context/util.vim
+++ b/autoload/context/util.vim
@@ -164,15 +164,13 @@ function! context#util#get_border_line(lines, level, indent, winid) abort
     let line_len = c.size_w - c.sign_width - c.number_width - a:indent - 1
     let border_char = g:context.char_border
     if !g:context.show_tag
-        " here the NB space belongs to the border part
-        let border_text = repeat(g:context.char_border, line_len) . ' '
+        let border_text = repeat(g:context.char_border, line_len) . ' '
         return [context#line#make_highlight(0, border_char, a:level, a:indent, border_text, g:context.highlight_border)]
     endif
 
     let line_len -= len(s:context_buffer_name) + 1
     let border_text = repeat(g:context.char_border, line_len)
-    " here the NB space belongs to the tag part (for minor highlighting reasons)
-    let tag_text = ' ' . s:context_buffer_name . ' '
+    let tag_text = ' ' . s:context_buffer_name
     return [
                 \ context#line#make_highlight(0, border_char, a:level, a:indent, border_text, g:context.highlight_border),
                 \ context#line#make_highlight(0, border_char, a:level, a:indent, tag_text,    g:context.highlight_tag)


### PR DESCRIPTION
>And stop using non breaking spaces because of the limitations of the previous default border character

https://github.com/wellle/context.vim/pull/81#issuecomment-679404088