### PR TITLE
Support earlier vim versions by passing argument to bufname

### DIFF
--- a/autoload/context.vim
+++ b/autoload/context.vim
@@ -110,7 +110,7 @@ function! context#update(...) abort
                 \ || &previewwindow
                 \ || mode() != 'n'
                 \ || !context#util#active()
-                \ || bufname() =~# '^term://'
+                \ || bufname("%") =~# '^term://'
         let w:context.needs_update = 0
         " NOTE: we still consider needs_layout even if this buffer is disabled
     endif


### PR DESCRIPTION
Hi there, I think this is a really awesome plugin! However I tried installing this plugin on vim version `8.0.1763` and I was getting `E119: Not enough arguments for function: bufname` on startup.

Reading the `:help bufname` for this version of vim:

```
bufname({expr})                                         bufname()
                The result is the name of a buffer, as it is displayed by the
                ":ls" command.
                If {expr} is a Number, that buffer number's name is given.
                Number zero is the alternate buffer for the current window.
                If {expr} is a String, it is used as a file-pattern to match
                with the buffer names.  This is always done like 'magic' is
                set and 'cpoptions' is empty.  When there is more than one
                match an empty string is returned.
                "" or "%" can be used for the current buffer, "#" for the
                alternate buffer.
                ...
```

Whereas newer version of vim have a clause `If {expr} is omitted the current buffer is used.`, this older version does not.

I tried this patch and the plugin works as expected for version `8.0.1763`.