### PR TITLE
Limit context length on shallow windows

### DIFF
--- a/autoload/context/util.vim
+++ b/autoload/context/util.vim
@@ -195,6 +195,18 @@ function! context#util#filter(context, line_number, consider_height) abort
     let max_height     = c.max_height
     let max_per_level  = c.max_per_level
 
+    " return an empty list when the window is not tall
+    " enough to display the context lines, otherwise the
+    " context display overwrites the buffer's status line
+    let scrolloff = &scrolloff
+    if scrolloff > winheight(0) / 2
+        let scrolloff = winheight(0) / 2
+    endif
+    let w_height_lim   = winheight(0) - scrolloff - 2
+    if w_height_lim <= 0
+        return [[], 0]
+    endif
+
     let height = 0
     let done = 0
     let lines = []
@@ -256,7 +268,7 @@ function! context#util#filter(context, line_number, consider_height) abort
         call extend(lines, limited)
     endfor
 
-    if len(lines) == 0
+    if len(lines) == 0 || len(lines) > w_height_lim
         return [[], 0]
     endif
 


### PR DESCRIPTION
Return an empty list when the window is not tall
enough to display the context lines, otherwise the
context display overwrites the buffer's status line.