### PR TITLE
Don't force popup redraw in recent nvim versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,14 +168,8 @@ let g:Context_border_indent = function('indent')
 ```
 When using popup windows we indent the border line to be aligned with the context base line. You can use this setting to use a different function to control that indent. Similar to `g:Context_indent` this function also takes a line number and returns an indentation number. For example you can disable that indentation at all to always show a full width border line like this: `let g:Context_border_indent = { -> 0 }`
 
-```vim
-let g:context_nvim_no_redraw = 0
-```
-There's an issue in Neovim which leads to some artefacts. To avoid those we manually refresh the screen after every context update. This can lead to screen flickering, see [#23][#23]. You disable those redraws (at the cost of visual artefacts) like this: `let g:context_nvim_no_redraw = 1`
-
 
 [indent-example]: https://github.com/wellle/context.vim/pull/45#issuecomment-582654810
-[#23]: https://github.com/wellle/context.vim/pull/23
 
 
 ## Commands

--- a/autoload/context/popup/nvim.vim
+++ b/autoload/context/popup/nvim.vim
@@ -60,15 +60,18 @@ function! context#popup#nvim#close(popup) abort
 endfunction
 
 function! context#popup#nvim#redraw_screen() abort
+    " NOTE: In earlier versions of Neovim there was an issue with redrawing
+    " popup. This has been fixed as of this minor version.
+    if has('nvim-0.5.0')
+        return
+    endif
+
     if g:context.nvim_no_redraw
         return
     endif
 
-    " NOTE: this redraws the screen. this is needed because there's
-    " a redraw issue: https://github.com/neovim/neovim/issues/11597
-    " TODO: remove this once that issue has been resolved
-    " sometimes it's not enough to :mode without :redraw we do it here because
-    " it's not needed for when we call update from layout
+    " On older versions we need to call :mode to force a hard redraw. In some
+    " cases we an additional call do :redraw is needed too.
     redraw
     mode
 endfunction

--- a/autoload/context/settings.vim
+++ b/autoload/context/settings.vim
@@ -102,7 +102,8 @@ function! context#settings#parse() abort
         let show_tag = 0
     endif
 
-    " hopefully temporary: disable nvim redraw to avoid flicker, see popup/nvim.vim
+    " Deprecated: Disable redraw to avoid flicker in older Neovim versions,
+    " see popup/nvim.vim
     let nvim_no_redraw = get(g:, 'context_nvim_no_redraw', 0)
 
     let logfile = get(g:, 'context_logfile', '')


### PR DESCRIPTION
Related to #23 and #68.

A long time ago there was a Neovim redraw issue because of which we had to call `:mode` to avoid stale context popups. This was fixed a while ago in Neovim, see https://github.com/neovim/neovim/issues/11597. So finally we remove this CPU intensive workaround to improve performance in Neovim. Sorry for taking so long to get this done.