### PR TITLE
Fix broken peek state if :ContextPeek is called twice

### DIFF
--- a/autoload/context.vim
+++ b/autoload/context.vim
@@ -51,7 +51,8 @@ endfunction
 function! context#peek() abort
     " enable and set the peek flag (to disable on next update)
     call context#enable('window')
-    let w:context.peek = 1
+    " set the flag correctly in case this function was called twice in a row
+    let w:context.peek = w:context.enabled
 endfunction
 
 function! context#update(...) abort


### PR DESCRIPTION
If `:ContextPeek` is called twice in a row without an update in between, the second call will hide the context buffer, but also set `context.peek` to 1, breaking any subsequent calls until another update is triggered. This PR makes sure the peek state matches the enabled state, so `:ContextPeek` will toggle the context buffer if it's called multiple times.